### PR TITLE
feat: homebrew support (#2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+# -----------------------------------------------------------------------------
+#  Binary release workflow on version tagged push.
+# -----------------------------------------------------------------------------
+# This workflow will build the binaries for various platforms and upload them
+# to the release page. It will also releases the package manifest for homebrew
+# to the tap repository: https://github.com/yoshi389111/homebrew-apps
+#
+# To use this workflow, you will need to create a secret env variable called
+# "GO_RELEASER_TOKEN" in the repository settings under:
+#
+#    - "Settings" -> "Security" -> "Secrets and variables" -> "Secrets" -> "New repository secret"
+#
+# The value of this secret should be a personal access token with the permission
+# to "repo" in its scope. You can create a new token here:
+#
+# - Create new token: https://github.com/settings/tokens/new
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # required for the changelog of goreleaser to work correctly.
+          fetch-depth: 0
+
+      # Setup Go
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      # Build and release. Releases for homebrew as well.
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          version: latest
+          args: release --config .goreleaser.yml --clean
+        env:
+          # Use specific token and not "secrets.GITHUB_TOKEN"(auto-created token)
+          # due to publishing to homebrew tap repository.
+          GITHUB_TOKEN: ${{ secrets.GO_RELEASER_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 go.work
 
 /target
+/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,69 @@
+# =============================================================================
+#  GoReleaser configuration file for git-caesar
+# =============================================================================
+#  For local testing run:
+#    goreleaser --skip-publish --clean --snapshot
+env:
+  - GO111MODULE=on
+
+before:
+  hooks:
+    - go mod download
+
+# List of OS and architectures to build binaries for.
+builds:
+  - env:
+      - CGO_ENABLED=0
+    binary: git-caesar
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    # Variant for ARM32
+    goarm:
+      - "5"
+      - "6"
+      - "7"
+    # Ignore ARM32 build for both macOS and Windows
+    ignore:
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -extldflags '-static' -X main.version={{.Version}} -X main.builtBy=goreleaser
+
+# macOS universal binaries. It will join the binaries for AMD64 and Amd64 into
+# a single binary. Suitable for Apple Silicon (Arm64) and Intel (amd64).
+universal_binaries:
+  -
+    name_template: 'git-caesar'
+    # Remove each after joining
+    replace: true
+
+# Homebrew configuration for macOS and Linux (Linuxbrew) packages.
+brews:
+  -
+    name: git-caesar
+    description: "Encrypt/decrypt files passwordlessly using GitHub's public key."
+    homepage: "https://github.com/yoshi389111/git-caesar"
+    folder: Formula
+    tap:
+      owner: yoshi389111
+      name: homebrew-apps
+    url_template: "https://github.com/yoshi389111/git-caesar/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    commit_author:
+      name: goreleaserbot
+      email: goreleaser@carlosbecker.com
+    download_strategy: CurlDownloadStrategy
+    install: |
+      bin.install "git-caesar"
+    test: |
+      system "#{bin}/git-caesar --version"

--- a/caesar/prvkeylib/prvkey.go
+++ b/caesar/prvkeylib/prvkey.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"syscall"
 
 	"github.com/yoshi389111/git-caesar/caesar"
 	ec "github.com/yoshi389111/git-caesar/caesar/ecdsa"
@@ -43,11 +42,11 @@ func GetPrvKey(filePath string) (caesar.PrivateKey, error) {
 }
 
 func readPassphrase() string {
-	if !terminal.IsTerminal(syscall.Stdin) {
+	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
 		return ""
 	}
 	fmt.Fprint(os.Stderr, "Enter passphrase: ")
-	bytePassword, _ := terminal.ReadPassword(syscall.Stdin)
+	bytePassword, _ := terminal.ReadPassword(int(os.Stdin.Fd()))
 	fmt.Fprintln(os.Stderr, "")
 	return string(bytePassword)
 }


### PR DESCRIPTION
Fixes #2 feature.

The workflow will trigger on version tagged push or manually triggered. It does not run the tests.

When triggered, it will build the binaries for various platforms and upload them to the release page. Then releases the package manifest for homebrew to the tap repository: 

- https://github.com/yoshi389111/homebrew-apps

# Before release

To use this workflow, you will need to create a secret env variable called "GO_RELEASER_TOKEN" in the repository settings under:

- "Settings" -> "Security" -> "Secrets and variables" -> "Secrets" -> "New repository secret"

The value of this secret should be a personal access token with the permission to "repo" in its scope. You can create a new token here:

- Create new token: https://github.com/settings/tokens/new

Hope this works 🤞 