### PR TITLE
Fix a bug in `toX25519PublicKey`

### DIFF
--- a/caesar/ed25519/toX25519.go
+++ b/caesar/ed25519/toX25519.go
@@ -34,7 +34,9 @@ func toX25519PublicKey(edPubKey *ed25519.PublicKey) (*ecdh.PublicKey, error) {
 	u := numer.Mod(numer.Mul(numer, denomInv), p)
 
 	// convert to little-endian
-	littleEndianU := toReverse(u.Bytes())
+	littleEndianU := make([]byte, 32)
+	u.FillBytes(littleEndianU)
+	littleEndianU = toReverse(littleEndianU)
 
 	// create x25519 public key
 	return ecdh.X25519().NewPublicKey(littleEndianU)

--- a/caesar/ed25519/toX25519.go
+++ b/caesar/ed25519/toX25519.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ed25519"
 	"crypto/sha512"
 	"math/big"
+
+	"errors"
 )
 
 func toX2519PrivateKey(edPrvKey *ed25519.PrivateKey) (*ecdh.PrivateKey, error) {
@@ -21,6 +23,10 @@ var p, _ = new(big.Int).SetString("7ffffffffffffffffffffffffffffffffffffffffffff
 var one = big.NewInt(1)
 
 func toX25519PublicKey(edPubKey *ed25519.PublicKey) (*ecdh.PublicKey, error) {
+	if len(*edPubKey) != ed25519.PublicKeySize {
+		return nil, errors.New("ed25519: bad public key length")
+	}
+
 	// convert to big-endian
 	bigEndianY := toReverse(*edPubKey)
 

--- a/caesar/ed25519/toX25519_test.go
+++ b/caesar/ed25519/toX25519_test.go
@@ -1,0 +1,57 @@
+package ed25519
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"testing"
+)
+
+func Test_toX25519PublicKey_fix_issue4(t *testing.T) {
+	pubGolden, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for index, test := range []*ed25519.PublicKey{
+		// control (generated key)
+		&pubGolden,
+		// x25519: 0xFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00
+		// u = 2^252-2 corresponds to y = (u-1)/(u+1) = (2^251-1)/(2^251) = 1-2^(-251)
+		{
+			0x09, 0x5d, 0x74, 0xd1, 0x45, 0x17, 0x5d, 0x74,
+			0xd1, 0x45, 0x17, 0x5d, 0x74, 0xd1, 0x45, 0x17,
+			0x5d, 0x74, 0xd1, 0x45, 0x17, 0x5d, 0x74, 0xd1,
+			0x45, 0x17, 0x5d, 0x74, 0xd1, 0x45, 0x17, 0x5d,
+		},
+		// x25519: 0x0300000000000000000000000000000000000000000000000000000000000000
+		// u = 3 corresponds to y = (u-1)/(u+1) = 1/2 = (p+1)/2
+		{
+			0xf7, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3f,
+		},
+	} {
+		// Require no error
+		_, err := toX25519PublicKey(test)
+		if err != nil {
+			t.Fatalf("#%d failed: a valid pub key with trailing zeros should not cause an error. %v",
+				index+1, err)
+		}
+	}
+}
+
+func Test_toX25519PublicKey_errors_with_invalid_length_keys(t *testing.T) {
+	t.Run("invalid length", func(t *testing.T) {
+		lengths := []int{0, 1, 31, 33, 64}
+		for _, length := range lengths {
+			badKey := ed25519.PublicKey(bytes.Repeat([]byte{0xFF}, length))
+
+			// Require error
+			_, err := toX25519PublicKey(&badKey)
+			if err == nil {
+				t.Fatalf("key length not equal to 32 should cause an error")
+			}
+		}
+	})
+}


### PR DESCRIPTION
If a bigint `u` is small, the length of `u.Bytes()` can be less than 32.

The following script exploits on this bug, finding a suitable `y` and causing a runtime error.
The probability of this bug happening is about 1/256 (when (the most significant byte of X25519 public key) = 0x00). This PR fixes the bug.

crack/main.go
```go
package main

import (
	"crypto/ecdh"
	"crypto/ed25519"
	"fmt"
	"math/big"

	myed25519 "github.com/yoshi389111/git-caesar/caesar/ed25519"
)

var p, _ = new(big.Int).SetString("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffed", 16)

func main() {
	c := 3
	for {
		key := make([]byte, 32)
		key[0] = byte(c)
		if _, err := ecdh.X25519().NewPublicKey(key); err == nil {
			break
		}
		c++
	}
	key := make([]byte, 32)
	key[0] = byte(c)
	pubkey, err := ecdh.X25519().NewPublicKey(key)
	if err != nil {
		panic(err)
	}
	fmt.Println(pubkey)

	u := big.NewInt(int64(c))
	one := big.NewInt(1)

	numer := new(big.Int).Sub(u, one)          // u-1
	denomInv := u.ModInverse(u.Add(one, u), p) // 1 / (u+1)
	// y = (u-1) / (u+1)
	y := numer.Mod(numer.Mul(numer, denomInv), p)
	littleEndianU := make([]byte, 32)
	y.FillBytes(littleEndianU)
	littleEndianU = toReverse(littleEndianU)
	pubEdKey := ed25519.PublicKey(littleEndianU)

	if _, _, err := myed25519.Encrypt(&pubEdKey, []byte("test")); err != nil {
		panic(err)
	}

}

func toReverse(input []byte) []byte {
	length := len(input)
	output := make([]byte, length)
	for i, b := range input {
		output[length-i-1] = b
	}
	return output
}
```

Output:
```
$ go run ./crack
&{0x1010bee40 [3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0] <nil>}
panic: Failed to convert X25519 to public key.
                crypto/ecdh: invalid public key

goroutine 1 [running]:
main.main()
        /Users/kobas-mac/srcview/git-caesar/crack/main.go:45 +0x3c8
exit status 2
```