### PR TITLE
:lady_beetle: fix: update public key handling to use pointer types …

### DIFF
--- a/caesar/pubkeylib/pubkey.go
+++ b/caesar/pubkeylib/pubkey.go
@@ -65,12 +65,12 @@ func GetPubKeys(target string) ([]caesar.PublicKey, error) {
 			continue
 		}
 		cryptoPubKey := sshCryptoPubKey.CryptoPublicKey()
-		if rsaPubKey, ok := cryptoPubKey.(rsa.PublicKey); ok {
+		if rsaPubKey, ok := cryptoPubKey.(*rsa.PublicKey); ok {
 			if 1024 <= rsaPubKey.N.BitLen() {
-				pubKeyList = append(pubKeyList, rs.NewPublicKey(rsaPubKey, sshPubKey))
+				pubKeyList = append(pubKeyList, rs.NewPublicKey(*rsaPubKey, sshPubKey))
 			}
-		} else if ecdsaPubKey, ok := cryptoPubKey.(ecdsa.PublicKey); ok {
-			pubKeyList = append(pubKeyList, ec.NewPublicKey(ecdsaPubKey, sshPubKey))
+		} else if ecdsaPubKey, ok := cryptoPubKey.(*ecdsa.PublicKey); ok {
+			pubKeyList = append(pubKeyList, ec.NewPublicKey(*ecdsaPubKey, sshPubKey))
 		} else if ed25519PubKey, ok := cryptoPubKey.(ed25519.PublicKey); ok {
 			pubKeyList = append(pubKeyList, ed.NewPublicKey(ed25519PubKey, sshPubKey))
 		}

--- a/caesar/pubkeylib/pubkey_test.go
+++ b/caesar/pubkeylib/pubkey_test.go
@@ -1,0 +1,81 @@
+package pubkeylib
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"os"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func generateRSAPublicKey(t *testing.T) ssh.PublicKey {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err := ssh.NewPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pub
+}
+
+func generateECDSAPublicKey(t *testing.T) ssh.PublicKey {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err := ssh.NewPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pub
+}
+
+func generateEd25519PublicKey(t *testing.T) ssh.PublicKey {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return sshPub
+}
+
+func Test_GetPubKeys_MultiType(t *testing.T) {
+	pubkeys := []ssh.PublicKey{
+		generateRSAPublicKey(t),
+		generateECDSAPublicKey(t),
+		generateEd25519PublicKey(t),
+	}
+
+	var authKeys string
+	for _, pk := range pubkeys {
+		authKeys += string(ssh.MarshalAuthorizedKey(pk))
+	}
+
+	tmpfile, err := os.CreateTemp("", "pubkeys")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if err := os.WriteFile(tmpfile.Name(), []byte(authKeys), 0600); err != nil {
+		t.Fatal(err)
+	}
+	tmpfile.Close()
+
+	keys, err := GetPubKeys(tmpfile.Name())
+	if err != nil {
+		t.Fatalf("GetPubKeys failed: %v", err)
+	}
+	if len(keys) != 3 {
+		t.Fatalf("Expected 3 keys, got %d", len(keys))
+	}
+}


### PR DESCRIPTION
… types and add tests for multi-type public keys

- fix #10

This pull request refines the handling of public keys in the `caesar/pubkeylib` package by improving type safety and adding comprehensive unit tests. The most important changes include switching to pointer-based type assertions for RSA and ECDSA public keys, ensuring proper dereferencing, and introducing a new test suite to validate support for multiple key types.

### Improvements to type handling:

* [`caesar/pubkeylib/pubkey.go`](diffhunk://#diff-2ec79080fef22c041760dded6e9a561036651c4ebd96efede572a73553601464L68-R73): Updated type assertions for RSA and ECDSA public keys to use pointer-based checks (`*rsa.PublicKey` and `*ecdsa.PublicKey`) for better type safety. Ensured proper dereferencing when creating new public keys.

### Addition of unit tests:

* [`caesar/pubkeylib/pubkey_test.go`](diffhunk://#diff-c5e53d07256425548442eb4dc2425feb2e9cc0ebc96a481593829be6c0c9a63aR1-R81): Added a new test suite (`Test_GetPubKeys_MultiType`) to validate the `GetPubKeys` function's ability to handle RSA, ECDSA, and Ed25519 public keys. Includes helper functions to generate test keys and uses a temporary file for testing.