### PR TITLE
:white_check_mark: test: add roundtrip test script for encryption and decryption validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,7 @@ build: ## Build
 test: ## Unit test
 	go test ./... --count=1 -v
 .PHONY: test
+
+roundtrip: ## Roundtrip test
+	./roundtrip.sh
+.PHONY: roundtrip

--- a/roundtrip.sh
+++ b/roundtrip.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu pipefail
+
+WORKDIR=$(mktemp -d)
+
+if [ ! -x target/git-caesar ]; then
+    echo "git-caesar not found." >&2
+    exit 1
+fi
+
+cp -p target/git-caesar "$WORKDIR"
+
+(
+    cd "$WORKDIR"
+
+    # generate key pairs
+    # for sender (Alice)
+    ssh-keygen -t rsa -b 2048 -f alice_rsa_key -N '' -q
+    ssh-keygen -t ecdsa -b 256 -f alice_ecdsa_key -N '' -q
+    ssh-keygen -t ed25519 -f alice_ed25519_key -N '' -q
+
+    # for receiver (Bob)
+    ssh-keygen -t rsa -b 2048 -f bob_rsa_key -N '' -q
+    ssh-keygen -t ecdsa -b 256 -f bob_ecdsa_key -N '' -q
+    ssh-keygen -t ed25519 -f bob_ed25519_key -N '' -q
+
+    cat bob_ecdsa_key.pub bob_ed25519_key.pub bob_rsa_key.pub > bob_pub_list.txt
+
+    echo "Veni, vidi, vici." > plain.txt
+    echo "Alea iacta est." >> plain.txt
+    echo "Et tu, Brute?" >> plain.txt
+
+    decrypt() {
+        ./git-caesar -d -k "bob_${2}_key" -u "alice_${1}_key.pub" -i "encrypted_${1}.bin" -o "decrypted_${1}_${2}.txt"
+        if diff plain.txt "decrypted_${1}_${2}.txt"; then
+            echo "Success. ${1} -> ${2}"
+        else
+            echo "Failed. ${1} -> ${2}"
+        fi
+        rm "decrypted_${1}_${2}.txt"
+    }
+
+    # encrypt (RSA)
+    ./git-caesar -k alice_rsa_key -u bob_pub_list.txt -i plain.txt -o encrypted_rsa.bin
+    # decrypt
+    decrypt rsa rsa
+    decrypt rsa ecdsa
+    decrypt rsa ed25519
+
+    # encrypt (ECDSA)
+    ./git-caesar -k alice_ecdsa_key -u bob_pub_list.txt -i plain.txt -o encrypted_ecdsa.bin
+
+    # decrypt
+    decrypt ecdsa rsa
+    decrypt ecdsa ecdsa
+    decrypt ecdsa ed25519
+
+    # encrypt (ED25519)
+    ./git-caesar -k alice_ed25519_key -u bob_pub_list.txt -i plain.txt -o encrypted_ed25519.bin
+
+    # decrypt
+    decrypt ed25519 rsa
+    decrypt ed25519 ecdsa
+    decrypt ed25519 ed25519
+)
+
+rm -rf "$WORKDIR"


### PR DESCRIPTION
This pull request introduces a new roundtrip test for validating encryption and decryption functionality using the `git-caesar` tool. It adds a corresponding `Makefile` target and a shell script (`roundtrip.sh`) to automate the process. The changes focus on enhancing testing coverage for cryptographic operations.

### Testing Enhancements:

* **Added `roundtrip` target in `Makefile`:** A new `roundtrip` test target was added to the `Makefile`, allowing developers to execute the roundtrip test using `./roundtrip.sh`. This complements the existing unit test target. (`[MakefileR18-R21](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R18-R21)`)
* **Created `roundtrip.sh` script:** This script performs end-to-end encryption and decryption tests with various key types (RSA, ECDSA, ED25519) for sender and receiver key pairs. It validates the correctness of the `git-caesar` tool by comparing decrypted files with the original plaintext. (`[roundtrip.shR1-R67](diffhunk://#diff-f1ce9a5e7528378548ab19ee991e8d1e917ffb697205086d61a7f601552eaeceR1-R67)`)