### PR TITLE
:recycle: refact: update ECDSA signing and verification methods for compatibility with ASN.1 encoding

### DIFF
--- a/caesar/ecdsa/ecdsa.go
+++ b/caesar/ecdsa/ecdsa.go
@@ -4,9 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/asn1"
 	"fmt"
-	"math/big"
 
 	"github.com/yoshi389111/git-caesar/caesar/aes"
 )
@@ -47,21 +45,12 @@ func Decrypt(prvKey *ecdsa.PrivateKey, peersPubKey *ecdsa.PublicKey, ciphertext 
 	return aes.Decrypt(sharedKey[:], ciphertext)
 }
 
-// sigParam is used for ASN.1 encoding/decoding of ECDSA signatures.
-type sigParam struct {
-	R, S *big.Int
-}
-
 // Sign creates an ECDSA signature for the given message.
 func Sign(prvKey *ecdsa.PrivateKey, message []byte) ([]byte, error) {
 	hash := sha256.Sum256(message)
-	r, s, err := ecdsa.Sign(rand.Reader, prvKey, hash[:])
+	sig, err := ecdsa.SignASN1(rand.Reader, prvKey, hash[:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign ecdsa: %w", err)
-	}
-	sig, err := asn1.Marshal(sigParam{R: r, S: s})
-	if err != nil {
-		return nil, fmt.Errorf("failed to ecdsa signature marshalling: %w", err)
 	}
 	return sig, nil
 }
@@ -69,10 +58,5 @@ func Sign(prvKey *ecdsa.PrivateKey, message []byte) ([]byte, error) {
 // Verify checks an ECDSA signature for the given message.
 func Verify(pubKey *ecdsa.PublicKey, message, sig []byte) bool {
 	hash := sha256.Sum256(message)
-	signature := &sigParam{}
-	_, err := asn1.Unmarshal(sig, signature)
-	if err != nil {
-		return false
-	}
-	return ecdsa.Verify(pubKey, hash[:], signature.R, signature.S)
+	return ecdsa.VerifyASN1(pubKey, hash[:], sig)
 }


### PR DESCRIPTION
This pull request refactors the ECDSA signature handling in the `caesar/ecdsa` package to use built-in ASN.1 methods (`SignASN1` and `VerifyASN1`) instead of custom encoding and decoding logic. Additionally, compatibility tests are added to ensure backward compatibility with the previous implementation.

### Refactoring ECDSA signature handling:

* [`caesar/ecdsa/ecdsa.go`](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L50-R61): Removed the custom `sigParam` struct and its associated encoding/decoding logic. Updated `Sign` and `Verify` functions to use `ecdsa.SignASN1` and `ecdsa.VerifyASN1`, simplifying the code and leveraging built-in methods for ASN.1 signature handling.

* [`caesar/ecdsa/ecdsa.go`](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L7-L9): Removed unused imports (`encoding/asn1` and `math/big`) as they are no longer needed after refactoring.

### Adding compatibility tests:

* [`caesar/ecdsa/ecdsa_test.go`](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dR160-R209): Introduced two new tests, `Test_Signature_Compatibility` and `Test_Verify_Compatibility`, to confirm that signatures created by the old implementation can be verified by the new implementation and vice versa. This ensures backward compatibility.

* [`caesar/ecdsa/ecdsa_test.go`](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dR8-R11): Added imports (`encoding/asn1`, `math/big`, and `crypto/sha256`) required for compatibility tests.…ompatibility with ASN.1 encoding