### PR TITLE
:recycle: refact: encryption and decryption methods to support versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ Usage:
 
 Application Options:
 
-  -h, --help                    print help and exit.
-  -v, --version                 print version and exit.
-  -u, --public=<target>         github account, url or file.
-  -k, --private=<id_file>       ssh private key file.
-  -i, --input=<input_file>      the path of the file to read. default: stdin
-  -o, --output=<output_file>    the path of the file to write. default: stdout
-  -d, --decrypt                 decryption mode.
+  -h, --help                        print help and exit.
+  -v, --version                     print version and exit.
+  -u, --public=<target>             github account, url or file.
+  -k, --private=<id_file>           ssh private key file.
+  -i, --input=<input_file>          the path of the file to read. default: stdin
+  -o, --output=<output_file>        the path of the file to write. default: stdout
+  -d, --decrypt                     decryption mode.
+  -F, --format-version=<version>    format version of the encrypted file. (default: 1)
 ```
 
 * `-u` specifies the location of the peer's public key. Get from `https://github.com/USER_NAME.keys` if the one specified looks like a GitHub username. If it starts with `http:` or `https:`, it will be fetched from the web. Otherwise, it will be determined as a file path. If you specify a file that looks like GitHub username, specify it with a path (e.g. `-u ./octacat`). Required for encryption. For decryption, perform signature verification if specified.
@@ -61,6 +62,7 @@ Application Options:
 * `-i` Input file. Plaintext file to be encrypted when encrypting. When decrypting, please specify the ciphertext file to be decrypted. If no options are specified, it reads from standard input.
 * `-o` output file. Outputs to standard output if no option is specified.
 * Specify `-d` for decrypt mode. Encrypted mode if not specified.
+* `-F` specifies the file version of the cipher file. Currently, only version 1 is valid.
 
 ## Supported algorithms
 
@@ -112,6 +114,6 @@ git-caesar -d -i secret.zip -o secret.txt
 
 ## Copyright and License
 
-(C) 2023 SATO, Yoshiyuki
+&copy; 2023 SATO, Yoshiyuki
 
 This software is released under the MIT License.

--- a/caesar/PrivateKey.go
+++ b/caesar/PrivateKey.go
@@ -1,9 +1,9 @@
 package caesar
 
 type PrivateKey interface {
-	ExtractShareKey(envelope Envelope) ([]byte, error)
+	ExtractShareKey(version string, envelope Envelope) ([]byte, error)
 
-	Sign(message []byte) ([]byte, error)
+	Sign(version string, message []byte) ([]byte, error)
 
 	GetAuthKey() (string, error)
 }

--- a/caesar/PublicKey.go
+++ b/caesar/PublicKey.go
@@ -1,9 +1,9 @@
 package caesar
 
 type PublicKey interface {
-	NewEnvelope(shareKey []byte) (Envelope, error)
+	NewEnvelope(version string, shareKey []byte) (Envelope, error)
 
-	Verify(message, sig []byte) bool
+	Verify(version string, message, sig []byte) bool
 
 	GetAuthKey() string
 }

--- a/caesar/aes/aes.go
+++ b/caesar/aes/aes.go
@@ -8,7 +8,17 @@ import (
 	"fmt"
 )
 
-func Encrypt(key, plaintext []byte) ([]byte, error) {
+func Encrypt(version string, key, plaintext []byte) ([]byte, error) {
+	switch version {
+	case "1":
+		return encryptV1(version, key, plaintext)
+	default:
+		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
+	}
+}
+
+func encryptV1(version string, key, plaintext []byte) ([]byte, error) {
+	_ = version // unused parameter
 	// pad the message with PKCS#7
 	padding := aes.BlockSize - len(plaintext)%aes.BlockSize
 	padtext := append(plaintext, bytes.Repeat([]byte{byte(padding)}, padding)...)
@@ -34,7 +44,17 @@ func Encrypt(key, plaintext []byte) ([]byte, error) {
 	return ciphertext, nil
 }
 
-func Decrypt(key, ciphertext []byte) ([]byte, error) {
+func Decrypt(version string, key, ciphertext []byte) ([]byte, error) {
+	switch version {
+	case "1":
+		return decryptV1(version, key, ciphertext)
+	default:
+		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
+	}
+}
+
+func decryptV1(version string, key, ciphertext []byte) ([]byte, error) {
+	_ = version // unused parameter
 	// Check if ciphertext is long enough to contain an IV
 	if len(ciphertext) < aes.BlockSize {
 		return nil, fmt.Errorf("ciphertext too short")

--- a/caesar/aes/aes_test.go
+++ b/caesar/aes/aes_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func Test_EncryptDecryptAesCbc32(t *testing.T) {
+func Test_Encrypt_Decrypt_AesCbc32_V1(t *testing.T) {
 	message := []byte("hello world AES-256-CBC")
 
 	key := make([]byte, 32)
@@ -16,12 +16,12 @@ func Test_EncryptDecryptAesCbc32(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ciphertext, err := Encrypt(key, []byte(message))
+	ciphertext, err := Encrypt("1", key, []byte(message))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	plaintext, err := Decrypt(key, ciphertext)
+	plaintext, err := Decrypt("1", key, ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +31,7 @@ func Test_EncryptDecryptAesCbc32(t *testing.T) {
 	}
 }
 
-func Test_EncryptDecryptAesCbc24(t *testing.T) {
+func Test_Encrypt_Decrypt_AesCbc24_V1(t *testing.T) {
 	message := []byte("hello world AES-192-CBC")
 
 	key := make([]byte, 24)
@@ -40,12 +40,12 @@ func Test_EncryptDecryptAesCbc24(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ciphertext, err := Encrypt(key, []byte(message))
+	ciphertext, err := Encrypt("1", key, []byte(message))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	plaintext, err := Decrypt(key, ciphertext)
+	plaintext, err := Decrypt("1", key, ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func Test_EncryptDecryptAesCbc24(t *testing.T) {
 	}
 }
 
-func Test_EncryptDecryptAesCbc16(t *testing.T) {
+func Test_Encrypt_Decrypt_AesCbc16_V1(t *testing.T) {
 	message := []byte("hello world AES-128-CBC")
 
 	key := make([]byte, 16)
@@ -64,12 +64,12 @@ func Test_EncryptDecryptAesCbc16(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ciphertext, err := Encrypt(key, []byte(message))
+	ciphertext, err := Encrypt("1", key, []byte(message))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	plaintext, err := Decrypt(key, ciphertext)
+	plaintext, err := Decrypt("1", key, ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/caesar/ecdsa/PrivateKey.go
+++ b/caesar/ecdsa/PrivateKey.go
@@ -20,7 +20,7 @@ func NewPrivateKey(prvKey ecdsa.PrivateKey) *PrivateKey {
 	}
 }
 
-func (p PrivateKey) ExtractShareKey(envelope caesar.Envelope) ([]byte, error) {
+func (p PrivateKey) ExtractShareKey(version string, envelope caesar.Envelope) ([]byte, error) {
 	envelopeEc, ok := envelope.(Envelope)
 	if !ok {
 		return nil, fmt.Errorf("envelope is not of type ecdsa.Envelope")
@@ -41,11 +41,11 @@ func (p PrivateKey) ExtractShareKey(envelope caesar.Envelope) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("crypto public key is not *ecdsa.PublicKey")
 	}
-	return Decrypt(&p.prvKey, pubKey, ciphertext)
+	return Decrypt(version, &p.prvKey, pubKey, ciphertext)
 }
 
-func (p PrivateKey) Sign(message []byte) ([]byte, error) {
-	return Sign(&p.prvKey, message)
+func (p PrivateKey) Sign(version string, message []byte) ([]byte, error) {
+	return Sign(version, &p.prvKey, message)
 }
 
 func (p PrivateKey) GetAuthKey() (string, error) {

--- a/caesar/ecdsa/PublicKey.go
+++ b/caesar/ecdsa/PublicKey.go
@@ -22,8 +22,8 @@ func NewPublicKey(pubKey ecdsa.PublicKey, sshPubKey ssh.PublicKey) *PublicKey {
 	}
 }
 
-func (p PublicKey) NewEnvelope(shareKey []byte) (caesar.Envelope, error) {
-	ciphertext, tempPubKey, err := Encrypt(&p.pubKey, shareKey)
+func (p PublicKey) NewEnvelope(version string, shareKey []byte) (caesar.Envelope, error) {
+	ciphertext, tempPubKey, err := Encrypt(version, &p.pubKey, shareKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt for ecdsa: %w", err)
 	}
@@ -41,8 +41,8 @@ func (p PublicKey) NewEnvelope(shareKey []byte) (caesar.Envelope, error) {
 	return envelope, nil
 }
 
-func (p PublicKey) Verify(message, sig []byte) bool {
-	return Verify(&p.pubKey, message, sig)
+func (p PublicKey) Verify(version string, message, sig []byte) bool {
+	return Verify(version, &p.pubKey, message, sig)
 }
 
 func (p PublicKey) GetAuthKey() string {

--- a/caesar/ecdsa/ecdsa_test.go
+++ b/caesar/ecdsa/ecdsa_test.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func Test_Encrypt_Decrypt_P256(t *testing.T) {
+func Test_Encrypt_Decrypt_P256_V1(t *testing.T) {
 	message := []byte("hello world --------------- 0256") // 32byte
 	alicePrvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -23,12 +23,12 @@ func Test_Encrypt_Decrypt_P256(t *testing.T) {
 	}
 	alicePubKey := &alicePrvKey.PublicKey
 
-	ciphertext, bobPubKey, err := Encrypt(alicePubKey, []byte(message))
+	ciphertext, bobPubKey, err := Encrypt("1", alicePubKey, []byte(message))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	plaintext, err := Decrypt(alicePrvKey, bobPubKey, ciphertext)
+	plaintext, err := Decrypt("1", alicePrvKey, bobPubKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +38,7 @@ func Test_Encrypt_Decrypt_P256(t *testing.T) {
 	}
 }
 
-func Test_Encrypt_Decrypt_P384(t *testing.T) {
+func Test_Encrypt_Decrypt_P384_V1(t *testing.T) {
 	message := []byte("hello world --------------- 0384") // 32byte
 	alicePrvKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
@@ -46,12 +46,12 @@ func Test_Encrypt_Decrypt_P384(t *testing.T) {
 	}
 	alicePubKey := &alicePrvKey.PublicKey
 
-	ciphertext, bobPubKey, err := Encrypt(alicePubKey, []byte(message))
+	ciphertext, bobPubKey, err := Encrypt("1", alicePubKey, []byte(message))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	plaintext, err := Decrypt(alicePrvKey, bobPubKey, ciphertext)
+	plaintext, err := Decrypt("1", alicePrvKey, bobPubKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func Test_Encrypt_Decrypt_P384(t *testing.T) {
 	}
 }
 
-func Test_Encrypt_Decrypt_P521(t *testing.T) {
+func Test_Encrypt_Decrypt_P521_V1(t *testing.T) {
 	message := []byte("hello world --------------- 0521") // 32byte
 	alicePrvKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	if err != nil {
@@ -69,12 +69,12 @@ func Test_Encrypt_Decrypt_P521(t *testing.T) {
 	}
 	alicePubKey := &alicePrvKey.PublicKey
 
-	ciphertext, bobPubKey, err := Encrypt(alicePubKey, []byte(message))
+	ciphertext, bobPubKey, err := Encrypt("1", alicePubKey, []byte(message))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	plaintext, err := Decrypt(alicePrvKey, bobPubKey, ciphertext)
+	plaintext, err := Decrypt("1", alicePrvKey, bobPubKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func Test_Encrypt_Decrypt_P521(t *testing.T) {
 	}
 }
 
-func Test_Sign_Verify_P521(t *testing.T) {
+func Test_Sign_Verify_P521_V1(t *testing.T) {
 	message := []byte("hello world --------------- 0521")
 	prvKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	if err != nil {
@@ -92,17 +92,17 @@ func Test_Sign_Verify_P521(t *testing.T) {
 	}
 	pubKey := &prvKey.PublicKey
 
-	sig, err := Sign(prvKey, message)
+	sig, err := Sign("1", prvKey, message)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !Verify(pubKey, message, sig) {
+	if !Verify("1", pubKey, message, sig) {
 		t.Fatal("verify failed")
 	}
 }
 
-func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
+func Test_NewEnvelope_ExtractShareKey_V1(t *testing.T) {
 	message := []byte("hello world --------------- 1024") // 32byte
 
 	prvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -119,12 +119,12 @@ func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
 	ecdsaPrvKey := NewPrivateKey(*prvKey)
 	ecdsaPubKey := NewPublicKey(*pubKey, sshPubKey)
 
-	addInfo, err := ecdsaPubKey.NewEnvelope(message)
+	addInfo, err := ecdsaPubKey.NewEnvelope("1", message)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	decrypted, err := ecdsaPrvKey.ExtractShareKey(addInfo)
+	decrypted, err := ecdsaPrvKey.ExtractShareKey("1", addInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
 	}
 }
 
-func Test_PrivateKeySign_PublickKeyVerify(t *testing.T) {
+func Test_PrivateKeySign_PublickKeyVerify_V1(t *testing.T) {
 	message := []byte("hello world --------------- 1024") // 32byte
 
 	prvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -149,12 +149,12 @@ func Test_PrivateKeySign_PublickKeyVerify(t *testing.T) {
 	ecdsaPrvKey := NewPrivateKey(*prvKey)
 	ecdsaPubKey := NewPublicKey(*pubKey, sshPubKey)
 
-	sig, err := ecdsaPrvKey.Sign(message)
+	sig, err := ecdsaPrvKey.Sign("1", message)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !ecdsaPubKey.Verify(message, sig) {
+	if !ecdsaPubKey.Verify("1", message, sig) {
 		t.Fatal("verify failed")
 	}
 }
@@ -163,7 +163,7 @@ type sigParam struct {
 	R, S *big.Int
 }
 
-func Test_Signature_Compatibility(t *testing.T) {
+func Test_Signature_Compatibility_V1(t *testing.T) {
 	message := []byte("hello world ------------- compat") // 32byte
 	prvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -181,12 +181,12 @@ func Test_Signature_Compatibility(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !Verify(pubKey, message, sigOld) {
+	if !Verify("1", pubKey, message, sigOld) {
 		t.Fatal("The signature of the old version is not verified by verifying the new version.")
 	}
 }
 
-func Test_Verify_Compatibility(t *testing.T) {
+func Test_Verify_Compatibility_V1(t *testing.T) {
 	message := []byte("hello world ------------- compat") // 32byte
 	prvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -195,7 +195,7 @@ func Test_Verify_Compatibility(t *testing.T) {
 	pubKey := &prvKey.PublicKey
 
 	hash := sha256.Sum256(message)
-	sigNew, err := Sign(prvKey, message)
+	sigNew, err := Sign("1", prvKey, message)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func Test_Verify_Compatibility(t *testing.T) {
 	}
 }
 
-func Test_Encrypt_Compatibility(t *testing.T) {
+func Test_Encrypt_Compatibility_V1(t *testing.T) {
 	message := []byte("hello world ------------- compat") // 32byte
 	peerPrvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -218,7 +218,7 @@ func Test_Encrypt_Compatibility(t *testing.T) {
 	peerPubKey := &peerPrvKey.PublicKey
 
 	// Encrypt using the new method
-	ciphertext, tempPubKey, err := Encrypt(peerPubKey, []byte(message))
+	ciphertext, tempPubKey, err := Encrypt("1", peerPubKey, []byte(message))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +227,7 @@ func Test_Encrypt_Compatibility(t *testing.T) {
 	curve := peerPrvKey.Curve
 	exchangedKey, _ := curve.ScalarMult(tempPubKey.X, tempPubKey.Y, peerPrvKey.D.Bytes())
 	sharedKey := sha256.Sum256(exchangedKey.Bytes())
-	plaintext, err := aes.Decrypt(sharedKey[:], ciphertext)
+	plaintext, err := aes.Decrypt("1", sharedKey[:], ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +237,7 @@ func Test_Encrypt_Compatibility(t *testing.T) {
 	}
 }
 
-func Test_Decrypt_Compatibility(t *testing.T) {
+func Test_Decrypt_Compatibility_V1(t *testing.T) {
 	message := []byte("hello world ------------- compat") // 32byte
 	peerPrvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -253,14 +253,14 @@ func Test_Decrypt_Compatibility(t *testing.T) {
 	}
 	exchangedKey, _ := curve.ScalarMult(peerPubKey.X, peerPubKey.Y, tempPrvKey.D.Bytes())
 	sharedKey := sha256.Sum256(exchangedKey.Bytes())
-	ciphertext, err := aes.Encrypt(sharedKey[:], message)
+	ciphertext, err := aes.Encrypt("1", sharedKey[:], message)
 	if err != nil {
 		t.Fatal(err)
 	}
 	tempPubKey := &tempPrvKey.PublicKey
 
 	// Decrypt using the new method
-	plaintext, err := Decrypt(peerPrvKey, tempPubKey, ciphertext)
+	plaintext, err := Decrypt("1", peerPrvKey, tempPubKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/caesar/ed25519/PrivateKey.go
+++ b/caesar/ed25519/PrivateKey.go
@@ -20,7 +20,7 @@ func NewPrivateKey(prvKey ed25519.PrivateKey) *PrivateKey {
 	}
 }
 
-func (p PrivateKey) ExtractShareKey(envelope caesar.Envelope) ([]byte, error) {
+func (p PrivateKey) ExtractShareKey(version string, envelope caesar.Envelope) ([]byte, error) {
 	envelopeEc, ok := envelope.(Envelope)
 	if !ok {
 		return nil, fmt.Errorf("envelope is not of type ed25519.Envelope")
@@ -41,11 +41,11 @@ func (p PrivateKey) ExtractShareKey(envelope caesar.Envelope) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("crypto public key is not ed25519.PublicKey")
 	}
-	return Decrypt(&p.prvKey, &pubKey, ciphertext)
+	return Decrypt(version, &p.prvKey, &pubKey, ciphertext)
 }
 
-func (p PrivateKey) Sign(message []byte) ([]byte, error) {
-	return Sign(&p.prvKey, message)
+func (p PrivateKey) Sign(version string, message []byte) ([]byte, error) {
+	return Sign(version, &p.prvKey, message)
 }
 
 func (p PrivateKey) GetAuthKey() (string, error) {

--- a/caesar/ed25519/PublicKey.go
+++ b/caesar/ed25519/PublicKey.go
@@ -22,8 +22,8 @@ func NewPublicKey(pubKey ed25519.PublicKey, sshPubKey ssh.PublicKey) *PublicKey 
 	}
 }
 
-func (p PublicKey) NewEnvelope(shareKey []byte) (caesar.Envelope, error) {
-	ciphertext, tempPubKey, err := Encrypt(&p.pubKey, shareKey)
+func (p PublicKey) NewEnvelope(version string, shareKey []byte) (caesar.Envelope, error) {
+	ciphertext, tempPubKey, err := Encrypt(version, &p.pubKey, shareKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt for ed25519: %w", err)
 	}
@@ -41,8 +41,8 @@ func (p PublicKey) NewEnvelope(shareKey []byte) (caesar.Envelope, error) {
 	return envelope, nil
 }
 
-func (p PublicKey) Verify(message, sig []byte) bool {
-	return Verify(&p.pubKey, message, sig)
+func (p PublicKey) Verify(version string, message, sig []byte) bool {
+	return Verify(version, &p.pubKey, message, sig)
 }
 
 func (p PublicKey) GetAuthKey() string {

--- a/caesar/ed25519/ed25519_test.go
+++ b/caesar/ed25519/ed25519_test.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func Test_Encrypt_Decrypt(t *testing.T) {
+func Test_Encrypt_Decrypt_V1(t *testing.T) {
 	message := []byte("hello world --------------- 0256") // 32byte
 
 	bobPubKey, bobPrvKey, err := ed25519.GenerateKey(rand.Reader)
@@ -18,12 +18,12 @@ func Test_Encrypt_Decrypt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ciphertext, alicePubKey, err := Encrypt(&bobPubKey, message)
+	ciphertext, alicePubKey, err := Encrypt("1", &bobPubKey, message)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	plaintext, err := Decrypt(&bobPrvKey, alicePubKey, ciphertext)
+	plaintext, err := Decrypt("1", &bobPrvKey, alicePubKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,24 +33,24 @@ func Test_Encrypt_Decrypt(t *testing.T) {
 	}
 }
 
-func Test_Sign_Verify(t *testing.T) {
+func Test_Sign_Verify_V1(t *testing.T) {
 	message := []byte("hello world --------------- 0521")
 	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	sig, err := Sign(&prvKey, message)
+	sig, err := Sign("1", &prvKey, message)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !Verify(&pubKey, message, sig) {
+	if !Verify("1", &pubKey, message, sig) {
 		t.Fatal("verify failed")
 	}
 }
 
-func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
+func Test_NewEnvelope_ExtractShareKey_V1(t *testing.T) {
 	message := []byte("hello world --------------- 1024") // 32byte
 
 	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
@@ -66,12 +66,12 @@ func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
 	ed25519PrvKey := NewPrivateKey(prvKey)
 	ed25519PubKey := NewPublicKey(pubKey, sshPubKey)
 
-	addInfo, err := ed25519PubKey.NewEnvelope(message)
+	addInfo, err := ed25519PubKey.NewEnvelope("1", message)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	decrypted, err := ed25519PrvKey.ExtractShareKey(addInfo)
+	decrypted, err := ed25519PrvKey.ExtractShareKey("1", addInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
 	}
 }
 
-func Test_PrivateKeySign_PublickKeyVerify(t *testing.T) {
+func Test_PrivateKeySign_PublickKeyVerify_V1(t *testing.T) {
 	message := []byte("hello world --------------- 1024") // 32byte
 
 	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
@@ -96,12 +96,12 @@ func Test_PrivateKeySign_PublickKeyVerify(t *testing.T) {
 	ed25519PrvKey := NewPrivateKey(prvKey)
 	ed25519PubKey := NewPublicKey(pubKey, sshPubKey)
 
-	sig, err := ed25519PrvKey.Sign(message)
+	sig, err := ed25519PrvKey.Sign("1", message)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !ed25519PubKey.Verify(message, sig) {
+	if !ed25519PubKey.Verify("1", message, sig) {
 		t.Fatal("verify failed")
 	}
 }

--- a/caesar/rsa/PrivateKey.go
+++ b/caesar/rsa/PrivateKey.go
@@ -20,7 +20,7 @@ func NewPrivateKey(prvKey rsa.PrivateKey) *PrivateKey {
 	}
 }
 
-func (p PrivateKey) ExtractShareKey(envelope caesar.Envelope) ([]byte, error) {
+func (p PrivateKey) ExtractShareKey(version string, envelope caesar.Envelope) ([]byte, error) {
 	envelopeRsa, ok := envelope.(Envelope)
 	if !ok {
 		return nil, fmt.Errorf("envelope is not of type rsa.Envelope")
@@ -29,11 +29,11 @@ func (p PrivateKey) ExtractShareKey(envelope caesar.Envelope) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to base64 decode `key` in envelope for rsa: %w", err)
 	}
-	return Decrypt(&p.prvKey, ciphertext)
+	return Decrypt(version, &p.prvKey, ciphertext)
 }
 
-func (p PrivateKey) Sign(message []byte) ([]byte, error) {
-	return Sign(&p.prvKey, message)
+func (p PrivateKey) Sign(version string, message []byte) ([]byte, error) {
+	return Sign(version, &p.prvKey, message)
 }
 
 func (p PrivateKey) GetAuthKey() (string, error) {

--- a/caesar/rsa/PublicKey.go
+++ b/caesar/rsa/PublicKey.go
@@ -22,8 +22,8 @@ func NewPublicKey(pubKey rsa.PublicKey, sshPubKey ssh.PublicKey) *PublicKey {
 	}
 }
 
-func (p PublicKey) NewEnvelope(shareKey []byte) (caesar.Envelope, error) {
-	ciphertext, err := Encrypt(&p.pubKey, shareKey)
+func (p PublicKey) NewEnvelope(version string, shareKey []byte) (caesar.Envelope, error) {
+	ciphertext, err := Encrypt(version, &p.pubKey, shareKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt for rsa: %w", err)
 	}
@@ -35,8 +35,8 @@ func (p PublicKey) NewEnvelope(shareKey []byte) (caesar.Envelope, error) {
 	return envelope, nil
 }
 
-func (p PublicKey) Verify(message, sig []byte) bool {
-	return Verify(&p.pubKey, message, sig)
+func (p PublicKey) Verify(version string, message, sig []byte) bool {
+	return Verify(version, &p.pubKey, message, sig)
 }
 
 func (p PublicKey) GetAuthKey() string {

--- a/caesar/rsa/rsa.go
+++ b/caesar/rsa/rsa.go
@@ -5,22 +5,63 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	"fmt"
 )
 
-func Encrypt(pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
+func Encrypt(version string, pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
+	switch version {
+	case "1":
+		return encryptV1(version, pubKey, plaintext)
+	default:
+		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
+	}
+}
+
+func encryptV1(version string, pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
+	_ = version // unused parameter
 	return rsa.EncryptOAEP(sha256.New(), rand.Reader, pubKey, plaintext, []byte{})
 }
 
-func Decrypt(prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
+func Decrypt(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
+	switch version {
+	case "1":
+		return decryptV1(version, prvKey, ciphertext)
+	default:
+		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
+	}
+}
+
+func decryptV1(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
+	_ = version // unused parameter
 	return rsa.DecryptOAEP(sha256.New(), rand.Reader, prvKey, ciphertext, []byte{})
 }
 
-func Sign(prvKey *rsa.PrivateKey, message []byte) ([]byte, error) {
+func Sign(version string, prvKey *rsa.PrivateKey, message []byte) ([]byte, error) {
+	switch version {
+	case "1":
+		return signV1(version, prvKey, message)
+	default:
+		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
+	}
+}
+
+func signV1(version string, prvKey *rsa.PrivateKey, message []byte) ([]byte, error) {
+	_ = version // unused parameter
 	hash := sha256.Sum256(message)
 	return rsa.SignPKCS1v15(nil, prvKey, crypto.SHA256, hash[:])
 }
 
-func Verify(pubKey *rsa.PublicKey, message, sig []byte) bool {
+func Verify(version string, pubKey *rsa.PublicKey, message, sig []byte) bool {
+	switch version {
+	case "1":
+		return verifyV1(version, pubKey, message, sig)
+	default:
+		return false // unknown version
+	}
+}
+
+func verifyV1(version string, pubKey *rsa.PublicKey, message, sig []byte) bool {
+	_ = version // unused parameter
 	hash := sha256.Sum256(message)
 	err := rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hash[:], sig)
 	return err == nil

--- a/caesar/rsa/rsa_test.go
+++ b/caesar/rsa/rsa_test.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func Test_EncryptDecryptRsaOaep1024(t *testing.T) {
+func Test_EncryptDecryptRsaOaep1024_V1(t *testing.T) {
 	message := []byte("hello world --------------- 1024") // 32byte
 
 	prvKey, err := rsa.GenerateKey(rand.Reader, 1024)
@@ -19,12 +19,12 @@ func Test_EncryptDecryptRsaOaep1024(t *testing.T) {
 	}
 	pubKey := &prvKey.PublicKey
 
-	ciphertext, err := Encrypt(pubKey, []byte(message))
+	ciphertext, err := Encrypt("1", pubKey, []byte(message))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	plaintext, err := Decrypt(prvKey, ciphertext)
+	plaintext, err := Decrypt("1", prvKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +34,7 @@ func Test_EncryptDecryptRsaOaep1024(t *testing.T) {
 	}
 }
 
-func Test_EncryptDecryptRsaOaep2048(t *testing.T) {
+func Test_EncryptDecryptRsaOaep2048_V1(t *testing.T) {
 	message := []byte("hello world --------------- 2048") // 32byte
 
 	prvKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -43,12 +43,12 @@ func Test_EncryptDecryptRsaOaep2048(t *testing.T) {
 	}
 	pubKey := &prvKey.PublicKey
 
-	ciphertext, err := Encrypt(pubKey, []byte(message))
+	ciphertext, err := Encrypt("1", pubKey, []byte(message))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	plaintext, err := Decrypt(prvKey, ciphertext)
+	plaintext, err := Decrypt("1", prvKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func Test_EncryptDecryptRsaOaep2048(t *testing.T) {
 	}
 }
 
-func Test_EncryptDecryptRsaOaep4096(t *testing.T) {
+func Test_EncryptDecryptRsaOaep4096_V1(t *testing.T) {
 	message := []byte("hello world --------------- 4096") // 32byte
 
 	prvKey, err := rsa.GenerateKey(rand.Reader, 4096)
@@ -67,12 +67,12 @@ func Test_EncryptDecryptRsaOaep4096(t *testing.T) {
 	}
 	pubKey := &prvKey.PublicKey
 
-	ciphertext, err := Encrypt(pubKey, []byte(message))
+	ciphertext, err := Encrypt("1", pubKey, []byte(message))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	plaintext, err := Decrypt(prvKey, ciphertext)
+	plaintext, err := Decrypt("1", prvKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func Test_EncryptDecryptRsaOaep4096(t *testing.T) {
 	}
 }
 
-func Test_SignVerifyRsa(t *testing.T) {
+func Test_SignVerifyRsa_V1(t *testing.T) {
 	message := []byte("hello world --------------- 0521")
 	prvKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -90,17 +90,17 @@ func Test_SignVerifyRsa(t *testing.T) {
 	}
 	pubKey := &prvKey.PublicKey
 
-	sig, err := Sign(prvKey, message)
+	sig, err := Sign("1", prvKey, message)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !Verify(pubKey, message, sig) {
+	if !Verify("1", pubKey, message, sig) {
 		t.Fatal("verify failed")
 	}
 }
 
-func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
+func Test_NewEnvelope_ExtractShareKey_V1(t *testing.T) {
 	message := []byte("hello world --------------- 1024") // 32byte
 
 	prvKey, err := rsa.GenerateKey(rand.Reader, 1024)
@@ -117,12 +117,12 @@ func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
 	rsaPrvKey := NewPrivateKey(*prvKey)
 	rsaPubKey := NewPublicKey(*pubKey, sshPubKey)
 
-	addInfo, err := rsaPubKey.NewEnvelope(message)
+	addInfo, err := rsaPubKey.NewEnvelope("1", message)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	decrypted, err := rsaPrvKey.ExtractShareKey(addInfo)
+	decrypted, err := rsaPrvKey.ExtractShareKey("1", addInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
 	}
 }
 
-func Test_PrivateKeySign_PublickKeyVerify(t *testing.T) {
+func Test_PrivateKeySign_PublickKeyVerify_V1(t *testing.T) {
 	message := []byte("hello world --------------- 1024") // 32byte
 
 	prvKey, err := rsa.GenerateKey(rand.Reader, 1024)
@@ -148,12 +148,12 @@ func Test_PrivateKeySign_PublickKeyVerify(t *testing.T) {
 	rsaPrvKey := NewPrivateKey(*prvKey)
 	rsaPubKey := NewPublicKey(*pubKey, sshPubKey)
 
-	sig, err := rsaPrvKey.Sign(message)
+	sig, err := rsaPrvKey.Sign("1", message)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !rsaPubKey.Verify(message, sig) {
+	if !rsaPubKey.Verify("1", message, sig) {
 		t.Fatal("verify failed")
 	}
 }

--- a/encrypt.go
+++ b/encrypt.go
@@ -13,7 +13,7 @@ import (
 	"github.com/yoshi389111/git-caesar/iolib"
 )
 
-func encrypt(peerPubKeys []caesar.PublicKey, prvKey caesar.PrivateKey, plaintext []byte) ([]byte, error) {
+func encrypt(version string, peerPubKeys []caesar.PublicKey, prvKey caesar.PrivateKey, plaintext []byte) ([]byte, error) {
 
 	// generate shared key (for AES-256-CBC)
 	shareKey := make([]byte, 32)
@@ -25,21 +25,21 @@ func encrypt(peerPubKeys []caesar.PublicKey, prvKey caesar.PrivateKey, plaintext
 	// encrypt shared key per public key
 	envelopes := make([]any, 0, len(peerPubKeys))
 	for _, peerPubKey := range peerPubKeys {
-		envelope, err := peerPubKey.NewEnvelope(shareKey)
+		envelope, err := peerPubKey.NewEnvelope(version, shareKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create envelope: %w", err)
 		}
 		envelopes = append(envelopes, envelope)
 	}
 
-	// encrypt the plaintext (by AES-256-CBC)
-	ciphertext, err := aes.Encrypt(shareKey, plaintext)
+	// encrypt the plaintext (by AES)
+	ciphertext, err := aes.Encrypt(version, shareKey, plaintext)
 	if err != nil {
 		return nil, fmt.Errorf("AES encryption failed: %w", err)
 	}
 
 	// sign the ciphertext
-	sig, err := prvKey.Sign(ciphertext)
+	sig, err := prvKey.Sign(version, ciphertext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign: %w", err)
 	}

--- a/encrypt_decrypt_test.go
+++ b/encrypt_decrypt_test.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func Test_encrypt_decrypt_rsa(t *testing.T) {
+func Test_encrypt_decrypt_rsa_V1(t *testing.T) {
 
 	alicePrvKey, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
@@ -78,7 +78,7 @@ func Test_encrypt_decrypt_rsa(t *testing.T) {
 
 	message := []byte("hello world")
 
-	zipBytes, err := encrypt(bobPubKeys, aliceCaesarPrvKey, message)
+	zipBytes, err := encrypt("1", bobPubKeys, aliceCaesarPrvKey, message)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func Test_encrypt_decrypt_rsa(t *testing.T) {
 	}
 }
 
-func Test_encrypt_decrypt_ecdsa(t *testing.T) {
+func Test_encrypt_decrypt_ecdsa_V1(t *testing.T) {
 
 	alicePrvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -171,7 +171,7 @@ func Test_encrypt_decrypt_ecdsa(t *testing.T) {
 
 	message := []byte("hello world")
 
-	zipBytes, err := encrypt(bobPubKeys, aliceCaesarPrvKey, message)
+	zipBytes, err := encrypt("1", bobPubKeys, aliceCaesarPrvKey, message)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,7 +204,7 @@ func Test_encrypt_decrypt_ecdsa(t *testing.T) {
 	}
 }
 
-func Test_encrypt_decrypt_ed25519(t *testing.T) {
+func Test_encrypt_decrypt_ed25519_V1(t *testing.T) {
 
 	alicePubKey, alicePrvKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
@@ -263,7 +263,7 @@ func Test_encrypt_decrypt_ed25519(t *testing.T) {
 
 	message := []byte("hello world")
 
-	zipBytes, err := encrypt(bobPubKeys, aliceCaesarPrvKey, message)
+	zipBytes, err := encrypt("1", bobPubKeys, aliceCaesarPrvKey, message)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/getOpts.go
+++ b/getOpts.go
@@ -10,16 +10,38 @@ import (
 	flags "github.com/jessevdk/go-flags"
 )
 
+type VersionType string
+
+var caesarJsonVersions = []VersionType{"1"}
+
+func IsValidCaesarJsonVersion(v string) bool {
+	for _, allowed := range caesarJsonVersions {
+		if v == string(allowed) {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *VersionType) UnmarshalFlag(value string) error {
+	if IsValidCaesarJsonVersion(value) {
+		*v = VersionType(value)
+		return nil
+	}
+	return fmt.Errorf("invalid format version: %s, allowed versions are: %v", value, caesarJsonVersions)
+}
+
 // ref. https://pkg.go.dev/github.com/jessevdk/go-flags
 type Options struct {
-	Help       bool   `short:"h" long:"help" description:"print help and exit."`
-	Version    bool   `short:"v" long:"version" description:"print version and exit."`
-	VersionAll bool   `short:"V" long:"version-all" hidden:"yes"`
-	PublicKey  string `short:"u" long:"public" value-name:"<target>" description:"github account, url or file."`
-	PrivateKey string `short:"k" long:"private" value-name:"<id_file>" description:"ssh private key file."`
-	InputPath  string `short:"i" long:"input" value-name:"<input_file>" description:"the path of the file to read. default: stdin"`
-	OutputPath string `short:"o" long:"output" value-name:"<output_file>" description:"the path of the file to write. default: stdout"`
-	Decrypt    bool   `short:"d" long:"decrypt" description:"decryption mode."`
+	Help          bool        `short:"h" long:"help" description:"print help and exit."`
+	Version       bool        `short:"v" long:"version" description:"print version and exit."`
+	VersionAll    bool        `short:"V" long:"version-all" hidden:"yes"`
+	PublicKey     string      `short:"u" long:"public" value-name:"<target>" description:"github account, url or file."`
+	PrivateKey    string      `short:"k" long:"private" value-name:"<id_file>" description:"ssh private key file."`
+	InputPath     string      `short:"i" long:"input" value-name:"<input_file>" description:"the path of the file to read. default: stdin"`
+	OutputPath    string      `short:"o" long:"output" value-name:"<output_file>" description:"the path of the file to write. default: stdout"`
+	Decrypt       bool        `short:"d" long:"decrypt" description:"decryption mode."`
+	FormatVersion VersionType `short:"F" long:"format-version" value-name:"<version>" description:"format version of the encrypted file." default:"1"`
 }
 
 func getOpts() Options {

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Recipient's public key not found.\n")
 			os.Exit(1)
 		}
-		outBytes, err = encrypt(peerPubKeys, prvKey, inBytes)
+		outBytes, err = encrypt(string(opts.FormatVersion), peerPubKeys, prvKey, inBytes)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "encrypt error: %v\n", err)
 			os.Exit(1)

--- a/roundtrip.sh
+++ b/roundtrip.sh
@@ -31,7 +31,7 @@ cp -p target/git-caesar "$WORKDIR"
     echo "Et tu, Brute?" >> plain.txt
 
     decrypt() {
-        ./git-caesar -d -k "bob_${2}_key" -u "alice_${1}_key.pub" -i "encrypted_${1}.bin" -o "decrypted_${1}_${2}.txt"
+        ./git-caesar -F 1 -d -k "bob_${2}_key" -u "alice_${1}_key.pub" -i "encrypted_${1}.bin" -o "decrypted_${1}_${2}.txt"
         if diff plain.txt "decrypted_${1}_${2}.txt"; then
             echo "Success. ${1} -> ${2}"
         else
@@ -41,14 +41,14 @@ cp -p target/git-caesar "$WORKDIR"
     }
 
     # encrypt (RSA)
-    ./git-caesar -k alice_rsa_key -u bob_pub_list.txt -i plain.txt -o encrypted_rsa.bin
+    ./git-caesar -F 1 -k alice_rsa_key -u bob_pub_list.txt -i plain.txt -o encrypted_rsa.bin
     # decrypt
     decrypt rsa rsa
     decrypt rsa ecdsa
     decrypt rsa ed25519
 
     # encrypt (ECDSA)
-    ./git-caesar -k alice_ecdsa_key -u bob_pub_list.txt -i plain.txt -o encrypted_ecdsa.bin
+    ./git-caesar -F 1 -k alice_ecdsa_key -u bob_pub_list.txt -i plain.txt -o encrypted_ecdsa.bin
 
     # decrypt
     decrypt ecdsa rsa
@@ -56,7 +56,7 @@ cp -p target/git-caesar "$WORKDIR"
     decrypt ecdsa ed25519
 
     # encrypt (ED25519)
-    ./git-caesar -k alice_ed25519_key -u bob_pub_list.txt -i plain.txt -o encrypted_ed25519.bin
+    ./git-caesar -F 1 -k alice_ed25519_key -u bob_pub_list.txt -i plain.txt -o encrypted_ed25519.bin
 
     # decrypt
     decrypt ed25519 rsa


### PR DESCRIPTION
This pull request introduces support for specifying a format version for encryption and decryption operations, along with corresponding updates to the `README.md`, core cryptographic functions, and test cases. The changes ensure backward compatibility with version 1 while laying the groundwork for future format versions.

### Core Functionality Updates:
* `caesar/PrivateKey.go` and `caesar/PublicKey.go`: Modified methods to accept a `version` parameter for operations like `ExtractShareKey`, `Sign`, `NewEnvelope`, and `Verify`. [[1]](diffhunk://#diff-c42f2557a59f39d31d337a6a9de148f77f39d3ec00c79be50c8fb53a63bfe0f5L4-R6) [[2]](diffhunk://#diff-0b4d966e279894f2abdae9dad83bcf431533d966bf89b0eaddaecbbe5d358632L4-R6)
* `caesar/aes/aes.go` and `caesar/ecdsa/ecdsa.go`: Refactored `Encrypt` and `Decrypt` functions to handle format versions, introducing version-specific implementations (`encryptV1`, `decryptV1`, etc.). [[1]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358L11-R21) [[2]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358L37-R57) [[3]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L15-R24) [[4]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L43-R69) [[5]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L71-R103)
* `caesar/ecdsa/PrivateKey.go` and `caesar/ecdsa/PublicKey.go`: Added version handling for ECDSA-specific encryption, decryption, signing, and verification operations. [[1]](diffhunk://#diff-43e8dbe6e25fc502b849ed1f0f5434b75221ef64e2d69282f657ee11bfedf58eL23-R23) [[2]](diffhunk://#diff-43e8dbe6e25fc502b849ed1f0f5434b75221ef64e2d69282f657ee11bfedf58eL44-R48) [[3]](diffhunk://#diff-add40044378714f7883617be42643669dda000a0fb9d72c07d03a604c8110809L25-R26) [[4]](diffhunk://#diff-add40044378714f7883617be42643669dda000a0fb9d72c07d03a604c8110809L44-R45)

### Test Updates:
* Updated test cases in `caesar/aes/aes_test.go` and `caesar/ecdsa/ecdsa_test.go` to include the format version parameter, ensuring compatibility with version 1. Renamed tests to reflect version-specific functionality. [[1]](diffhunk://#diff-8b6a05ca404546c5d76a6c96cdea82e00c1e247c6e04f8507afb4dd4498a89e4L10-R10) [[2]](diffhunk://#diff-8b6a05ca404546c5d76a6c96cdea82e00c1e247c6e04f8507afb4dd4498a89e4L19-R24) [[3]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dL18-R31) [[4]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dL41-R54)

### Compatibility Enhancements:
* Introduced compatibility tests to ensure that version 1 signatures and verifications align with legacy implementations. [[1]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dL166-R166) [[2]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dL184-R189)
 
### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R57-R65): Added the `-F` option to specify the format version of the encrypted file and updated the copyright symbol to `&copy;`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R57-R65) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L115-R117)
