### PR TITLE
:recycle: refact: add comments for encryption and decryption methods across AES, ECDSA, Ed25519, and RSA

### DIFF
--- a/caesar/aes/aes.go
+++ b/caesar/aes/aes.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 )
 
+// Encrypt encrypts a message using AES-256.
 func Encrypt(version string, key, plaintext []byte) ([]byte, error) {
 	switch version {
 	case "1":
@@ -17,8 +18,10 @@ func Encrypt(version string, key, plaintext []byte) ([]byte, error) {
 	}
 }
 
+// Encrypt encrypts a message using AES-256-CBC with PKCS#7 padding.
 func encryptV1(version string, key, plaintext []byte) ([]byte, error) {
 	_ = version // unused parameter
+
 	// pad the message with PKCS#7
 	padding := aes.BlockSize - len(plaintext)%aes.BlockSize
 	padtext := append(plaintext, bytes.Repeat([]byte{byte(padding)}, padding)...)
@@ -44,6 +47,7 @@ func encryptV1(version string, key, plaintext []byte) ([]byte, error) {
 	return ciphertext, nil
 }
 
+// Decrypt decrypts a message using AES-256.
 func Decrypt(version string, key, ciphertext []byte) ([]byte, error) {
 	switch version {
 	case "1":
@@ -53,8 +57,10 @@ func Decrypt(version string, key, ciphertext []byte) ([]byte, error) {
 	}
 }
 
+// Decrypt decrypts a message using AES-256-CBC with PKCS#7 padding.
 func decryptV1(version string, key, ciphertext []byte) ([]byte, error) {
 	_ = version // unused parameter
+
 	// Check if ciphertext is long enough to contain an IV
 	if len(ciphertext) < aes.BlockSize {
 		return nil, fmt.Errorf("ciphertext too short")

--- a/caesar/ed25519/ed25519.go
+++ b/caesar/ed25519/ed25519.go
@@ -10,6 +10,7 @@ import (
 	"github.com/yoshi389111/git-caesar/caesar/aes"
 )
 
+// Encrypt encrypts a message using X25519 key exchange and AES-256-CBC.
 func Encrypt(version string, otherPubKey *ed25519.PublicKey, message []byte) ([]byte, *ed25519.PublicKey, error) {
 	switch version {
 	case "1":
@@ -52,6 +53,7 @@ func encryptV1(version string, otherPubKey *ed25519.PublicKey, message []byte) (
 	return ciphertext, &tempEdPubKey, nil
 }
 
+// Decrypt decrypts a message using X25519 key exchange and AES-256-CBC.
 func Decrypt(version string, prvKey *ed25519.PrivateKey, otherPubKey *ed25519.PublicKey, ciphertext []byte) ([]byte, error) {
 	switch version {
 	case "1":
@@ -90,10 +92,15 @@ func exchangeKey(xPrvKey *ecdh.PrivateKey, xPubKey *ecdh.PublicKey) ([]byte, err
 	if err != nil {
 		return nil, err // don't wrap
 	}
+
+	// When using the exchanged key as an encryption key,
+	// HKDF or similar should be used instead of SHA-2,
+	// but SHA-2 is used for backward compatibility.
 	sharedKey := sha256.Sum256(exchangedKey)
 	return sharedKey[:], nil
 }
 
+// Sign creates a signature for the given message using the provided private key.
 func Sign(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte, error) {
 	switch version {
 	case "1":
@@ -105,11 +112,15 @@ func Sign(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte, e
 
 func signV1(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte, error) {
 	_ = version // unused parameter
+
+	// In the case of ed25519, hashing before signing/verifying is not required,
+	// but it is done for backwards compatibility.
 	hash := sha256.Sum256(message)
 	sig := ed25519.Sign(*prvKey, hash[:])
 	return sig, nil
 }
 
+// Verify checks if the signature is valid for the given message and public key.
 func Verify(version string, pubKey *ed25519.PublicKey, message, sig []byte) bool {
 	switch version {
 	case "1":
@@ -121,6 +132,9 @@ func Verify(version string, pubKey *ed25519.PublicKey, message, sig []byte) bool
 
 func verifyV1(version string, pubKey *ed25519.PublicKey, message, sig []byte) bool {
 	_ = version // unused parameter
+
+	// In the case of ed25519, hashing before signing/verifying is not required,
+	// but it is done for backwards compatibility.
 	hash := sha256.Sum256(message)
 	return ed25519.Verify(*pubKey, hash[:], sig)
 }

--- a/caesar/rsa/rsa.go
+++ b/caesar/rsa/rsa.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 )
 
+// Encrypt encrypts a message using RSA OAEP with SHA-256.
 func Encrypt(version string, pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
 	switch version {
 	case "1":
@@ -19,9 +20,11 @@ func Encrypt(version string, pubKey *rsa.PublicKey, plaintext []byte) ([]byte, e
 
 func encryptV1(version string, pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
 	_ = version // unused parameter
+
 	return rsa.EncryptOAEP(sha256.New(), rand.Reader, pubKey, plaintext, []byte{})
 }
 
+// Decrypt decrypts a message using RSA OAEP with SHA-256.
 func Decrypt(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
 	switch version {
 	case "1":
@@ -33,9 +36,11 @@ func Decrypt(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte,
 
 func decryptV1(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
 	_ = version // unused parameter
+
 	return rsa.DecryptOAEP(sha256.New(), rand.Reader, prvKey, ciphertext, []byte{})
 }
 
+// Sign signs a message using RSA PKCS#1 v1.5 with SHA-256.
 func Sign(version string, prvKey *rsa.PrivateKey, message []byte) ([]byte, error) {
 	switch version {
 	case "1":
@@ -47,10 +52,12 @@ func Sign(version string, prvKey *rsa.PrivateKey, message []byte) ([]byte, error
 
 func signV1(version string, prvKey *rsa.PrivateKey, message []byte) ([]byte, error) {
 	_ = version // unused parameter
+
 	hash := sha256.Sum256(message)
 	return rsa.SignPKCS1v15(nil, prvKey, crypto.SHA256, hash[:])
 }
 
+// Verify verifies a signature using RSA PKCS#1 v1.5 with SHA-256.
 func Verify(version string, pubKey *rsa.PublicKey, message, sig []byte) bool {
 	switch version {
 	case "1":
@@ -62,6 +69,7 @@ func Verify(version string, pubKey *rsa.PublicKey, message, sig []byte) bool {
 
 func verifyV1(version string, pubKey *rsa.PublicKey, message, sig []byte) bool {
 	_ = version // unused parameter
+
 	hash := sha256.Sum256(message)
 	err := rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hash[:], sig)
 	return err == nil


### PR DESCRIPTION
This pull request introduces comprehensive documentation improvements and backward compatibility adjustments across cryptographic implementations in the `caesar` package. The changes include adding detailed comments to encryption, decryption, signing, and verification functions, as well as ensuring compatibility with legacy systems by maintaining specific hashing and key derivation practices.

### Documentation Improvements:
* [`caesar/aes/aes.go`](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358R11): Added comments to `Encrypt`, `Decrypt`, `encryptV1`, and `decryptV1` functions, specifying the use of AES-256-CBC with PKCS#7 padding. [[1]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358R11) [[2]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358R21-R24) [[3]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358R50) [[4]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358R60-R63)
* [`caesar/ecdsa/ecdsa.go`](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L14): Improved comments for cryptographic operations, including key exchange, signing, and verification, highlighting backward compatibility adjustments such as hashing before signing/verifying. [[1]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L14) [[2]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941R117) [[3]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941R138)
* [`caesar/ed25519/ed25519.go`](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R13): Added comments for encryption, decryption, signing, and verification functions, emphasizing the use of SHA-256 for compatibility despite Ed25519 not requiring pre-hashing. [[1]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R13) [[2]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R56) [[3]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R115-R123) [[4]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R135-R137)
* [`caesar/rsa/rsa.go`](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R11): Documented RSA operations using OAEP and PKCS#1 v1.5 with SHA-256, ensuring clarity for encryption, decryption, signing, and verification functions. [[1]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R11) [[2]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R23-R27) [[3]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R39-R43) [[4]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R55-R60) [[5]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R72)

### Backward Compatibility Adjustments:
* [`caesar/ecdsa/ecdsa.go`](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L49-R55): Modified key exchange and signing processes to delete leading zeros and use SHA-256 for key derivation and hashing, maintaining compatibility with legacy systems. [[1]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L49-R55) [[2]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L86-R99)
* [`caesar/ed25519/ed25519.go`](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R95-R103): Ensured hashing of messages before signing and verifying, aligning with legacy practices despite Ed25519's inherent support for direct signing. [[1]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R95-R103) [[2]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R115-R123) [[3]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R135-R137)