### PR TITLE
Refactor: Replace Temporary Keys with Ephemeral Keys

### DIFF
--- a/caesar/aes/aes_test.go
+++ b/caesar/aes/aes_test.go
@@ -21,6 +21,15 @@ func Test_Encrypt_Decrypt_AesCbc32_V1(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ciphertext2, err := Encrypt("1", key, []byte(message))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Equal(ciphertext, ciphertext2) {
+		t.Fatal("ciphertexts should not be equal")
+	}
+
 	plaintext, err := Decrypt("1", key, ciphertext)
 	if err != nil {
 		t.Fatal(err)
@@ -28,6 +37,15 @@ func Test_Encrypt_Decrypt_AesCbc32_V1(t *testing.T) {
 
 	if !bytes.Equal(message, plaintext) {
 		t.Fatal(hex.Dump(plaintext))
+	}
+
+	plaintext2, err := Decrypt("1", key, ciphertext2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(message, plaintext2) {
+		t.Fatal(hex.Dump(plaintext2))
 	}
 }
 
@@ -45,6 +63,15 @@ func Test_Encrypt_Decrypt_AesCbc24_V1(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ciphertext2, err := Encrypt("1", key, []byte(message))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Equal(ciphertext, ciphertext2) {
+		t.Fatal("ciphertexts should not be equal")
+	}
+
 	plaintext, err := Decrypt("1", key, ciphertext)
 	if err != nil {
 		t.Fatal(err)
@@ -52,6 +79,15 @@ func Test_Encrypt_Decrypt_AesCbc24_V1(t *testing.T) {
 
 	if !bytes.Equal(message, plaintext) {
 		t.Fatal(hex.Dump(plaintext))
+	}
+
+	plaintext2, err := Decrypt("1", key, ciphertext2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(message, plaintext2) {
+		t.Fatal(hex.Dump(plaintext2))
 	}
 }
 
@@ -69,6 +105,15 @@ func Test_Encrypt_Decrypt_AesCbc16_V1(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ciphertext2, err := Encrypt("1", key, []byte(message))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Equal(ciphertext, ciphertext2) {
+		t.Fatal("ciphertexts should not be equal")
+	}
+
 	plaintext, err := Decrypt("1", key, ciphertext)
 	if err != nil {
 		t.Fatal(err)
@@ -76,5 +121,14 @@ func Test_Encrypt_Decrypt_AesCbc16_V1(t *testing.T) {
 
 	if !bytes.Equal(message, plaintext) {
 		t.Fatal(hex.Dump(plaintext))
+	}
+
+	plaintext2, err := Decrypt("1", key, ciphertext2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(message, plaintext2) {
+		t.Fatal(hex.Dump(plaintext2))
 	}
 }

--- a/caesar/ecdsa/PublicKey.go
+++ b/caesar/ecdsa/PublicKey.go
@@ -23,11 +23,11 @@ func NewPublicKey(pubKey ecdsa.PublicKey, sshPubKey ssh.PublicKey) *PublicKey {
 }
 
 func (p PublicKey) NewEnvelope(version string, shareKey []byte) (caesar.Envelope, error) {
-	ciphertext, tempPubKey, err := Encrypt(version, &p.pubKey, shareKey)
+	ciphertext, ephemeralPubKey, err := Encrypt(version, &p.pubKey, shareKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt for ecdsa: %w", err)
 	}
-	senderSSHPubKey, err := ssh.NewPublicKey(tempPubKey)
+	senderSSHPubKey, err := ssh.NewPublicKey(ephemeralPubKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate sender's ssh.PublicKey for ecdsa: %w", err)
 	}

--- a/caesar/ecdsa/ecdsa_test.go
+++ b/caesar/ecdsa/ecdsa_test.go
@@ -28,6 +28,15 @@ func Test_Encrypt_Decrypt_P256_V1(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ciphertext2, bobPubKey2, err := Encrypt("1", alicePubKey, []byte(message))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Equal(ciphertext, ciphertext2) {
+		t.Fatal("ciphertexts should not be equal")
+	}
+
 	plaintext, err := Decrypt("1", alicePrvKey, bobPubKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
@@ -35,6 +44,15 @@ func Test_Encrypt_Decrypt_P256_V1(t *testing.T) {
 
 	if !bytes.Equal(message, plaintext) {
 		t.Fatal(hex.Dump(plaintext))
+	}
+
+	plaintext2, err := Decrypt("1", alicePrvKey, bobPubKey2, ciphertext2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(message, plaintext2) {
+		t.Fatal(hex.Dump(plaintext2))
 	}
 }
 
@@ -51,6 +69,15 @@ func Test_Encrypt_Decrypt_P384_V1(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ciphertext2, bobPubKey2, err := Encrypt("1", alicePubKey, []byte(message))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Equal(ciphertext, ciphertext2) {
+		t.Fatal("ciphertexts should not be equal")
+	}
+
 	plaintext, err := Decrypt("1", alicePrvKey, bobPubKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
@@ -58,6 +85,15 @@ func Test_Encrypt_Decrypt_P384_V1(t *testing.T) {
 
 	if !bytes.Equal(message, plaintext) {
 		t.Fatal(hex.Dump(plaintext))
+	}
+
+	plaintext2, err := Decrypt("1", alicePrvKey, bobPubKey2, ciphertext2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(message, plaintext2) {
+		t.Fatal(hex.Dump(plaintext2))
 	}
 }
 
@@ -74,6 +110,15 @@ func Test_Encrypt_Decrypt_P521_V1(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ciphertext2, bobPubKey2, err := Encrypt("1", alicePubKey, []byte(message))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Equal(ciphertext, ciphertext2) {
+		t.Fatal("ciphertexts should not be equal")
+	}
+
 	plaintext, err := Decrypt("1", alicePrvKey, bobPubKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
@@ -81,6 +126,15 @@ func Test_Encrypt_Decrypt_P521_V1(t *testing.T) {
 
 	if !bytes.Equal(message, plaintext) {
 		t.Fatal(hex.Dump(plaintext))
+	}
+
+	plaintext2, err := Decrypt("1", alicePrvKey, bobPubKey2, ciphertext2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(message, plaintext2) {
+		t.Fatal(hex.Dump(plaintext2))
 	}
 }
 

--- a/caesar/ed25519/PublicKey.go
+++ b/caesar/ed25519/PublicKey.go
@@ -23,11 +23,11 @@ func NewPublicKey(pubKey ed25519.PublicKey, sshPubKey ssh.PublicKey) *PublicKey 
 }
 
 func (p PublicKey) NewEnvelope(version string, shareKey []byte) (caesar.Envelope, error) {
-	ciphertext, tempPubKey, err := Encrypt(version, &p.pubKey, shareKey)
+	ciphertext, ephemeralPubKey, err := Encrypt(version, &p.pubKey, shareKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt for ed25519: %w", err)
 	}
-	senderSSHPubKey, err := ssh.NewPublicKey(*tempPubKey)
+	senderSSHPubKey, err := ssh.NewPublicKey(*ephemeralPubKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate sender's ssh.PublicKey for ed25519: %w", err)
 	}

--- a/caesar/ed25519/ed25519.go
+++ b/caesar/ed25519/ed25519.go
@@ -21,8 +21,8 @@ func Encrypt(version string, otherPubKey *ed25519.PublicKey, message []byte) ([]
 }
 
 func encryptV1(version string, otherPubKey *ed25519.PublicKey, message []byte) ([]byte, *ed25519.PublicKey, error) {
-	// generate temporary key pair
-	tempEdPubKey, tempEdPrvKey, err := ed25519.GenerateKey(rand.Reader)
+	// generate ephemeral key pair
+	ephemeralEdPubKey, ephemeralEdPrvKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate ephemeral key pair for ed25519: %w", err)
 	}
@@ -34,7 +34,7 @@ func encryptV1(version string, otherPubKey *ed25519.PublicKey, message []byte) (
 	}
 
 	// convert ed25519 private key to x25519 private key
-	xPrvKey, err := toX25519PrivateKey(&tempEdPrvKey)
+	xPrvKey, err := toX25519PrivateKey(&ephemeralEdPrvKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to convert ed25519 private key to X25519 private key: %w", err)
 	}
@@ -50,7 +50,7 @@ func encryptV1(version string, otherPubKey *ed25519.PublicKey, message []byte) (
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to AES encryption for ed25519: %w", err)
 	}
-	return ciphertext, &tempEdPubKey, nil
+	return ciphertext, &ephemeralEdPubKey, nil
 }
 
 // Decrypt decrypts a message using X25519 key exchange and AES-256-CBC.

--- a/caesar/ed25519/ed25519_test.go
+++ b/caesar/ed25519/ed25519_test.go
@@ -23,6 +23,15 @@ func Test_Encrypt_Decrypt_V1(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ciphertext2, alicePubKey2, err := Encrypt("1", &bobPubKey, message)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Equal(ciphertext, ciphertext2) {
+		t.Fatal("ciphertexts should not be equal")
+	}
+
 	plaintext, err := Decrypt("1", &bobPrvKey, alicePubKey, ciphertext)
 	if err != nil {
 		t.Fatal(err)
@@ -30,6 +39,15 @@ func Test_Encrypt_Decrypt_V1(t *testing.T) {
 
 	if !bytes.Equal(message, plaintext) {
 		t.Fatal(hex.Dump(plaintext))
+	}
+
+	plaintext2, err := Decrypt("1", &bobPrvKey, alicePubKey2, ciphertext2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(message, plaintext2) {
+		t.Fatal(hex.Dump(plaintext2))
 	}
 }
 


### PR DESCRIPTION
This pull request refines encryption and decryption logic across multiple cryptographic implementations (`AES`, `ECDSA`, and `Ed25519`) by introducing ephemeral key generation and improving test coverage. The most significant changes include replacing "temporary" keys with "ephemeral" keys for enhanced clarity and security, updating encryption descriptions to reflect these changes, and adding additional test cases to ensure ciphertext uniqueness and proper decryption.

### Key Changes by Theme:

#### Ephemeral Key Generation:
* [`caesar/ecdsa/ecdsa.go`](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L26-R32): Replaced "temporary" keys with "ephemeral" keys in the `Encrypt` and `encryptV1` methods to improve clarity and align terminology with cryptographic standards. Updated corresponding variable names and comments. [[1]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L26-R32) [[2]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L57-R65) [[3]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L101-R101)
* [`caesar/ed25519/ed25519.go`](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464L24-R25): Changed "temporary" key pair generation to "ephemeral" key pair generation in `encryptV1`, along with variable name updates and comments. [[1]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464L24-R25) [[2]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464L37-R37) [[3]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464L53-R53)

#### Encryption Description Updates:
* [`caesar/ecdsa/ecdsa.go`](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L13-R13): Updated comments to reflect the use of AES-256 instead of AES-256-CBC for encryption and decryption. [[1]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L13-R13) [[2]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L57-R65) [[3]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L101-R101)
* [`caesar/ed25519/ed25519.go`](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464L53-R53): Updated comments to reflect the use of AES-256 instead of AES-256-CBC for encryption.

#### Test Coverage Enhancements:
* [`caesar/aes/aes_test.go`](diffhunk://#diff-8b6a05ca404546c5d76a6c96cdea82e00c1e247c6e04f8507afb4dd4498a89e4R24-R32): Added tests for AES encryption to verify that ciphertexts generated with the same input differ due to unique initialization vectors. Also tested decryption of both ciphertexts to ensure correctness. [[1]](diffhunk://#diff-8b6a05ca404546c5d76a6c96cdea82e00c1e247c6e04f8507afb4dd4498a89e4R24-R32) [[2]](diffhunk://#diff-8b6a05ca404546c5d76a6c96cdea82e00c1e247c6e04f8507afb4dd4498a89e4R41-R49) [[3]](diffhunk://#diff-8b6a05ca404546c5d76a6c96cdea82e00c1e247c6e04f8507afb4dd4498a89e4R66-R74) [[4]](diffhunk://#diff-8b6a05ca404546c5d76a6c96cdea82e00c1e247c6e04f8507afb4dd4498a89e4R83-R91) [[5]](diffhunk://#diff-8b6a05ca404546c5d76a6c96cdea82e00c1e247c6e04f8507afb4dd4498a89e4R108-R116) [[6]](diffhunk://#diff-8b6a05ca404546c5d76a6c96cdea82e00c1e247c6e04f8507afb4dd4498a89e4R125-R133)
* [`caesar/ecdsa/ecdsa_test.go`](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dR31-R39): Added similar tests for ECDSA encryption and decryption, ensuring ciphertext uniqueness and proper decryption. [[1]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dR31-R39) [[2]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dR48-R56) [[3]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dR72-R80) [[4]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dR89-R97) [[5]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dR113-R121) [[6]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dR130-R138)
* [`caesar/ed25519/ed25519_test.go`](diffhunk://#diff-6caa8f42ce959bf93a99ced151207a1853619e5d15e3f85a7127806b7781f3dbR26-R34): Enhanced tests for Ed25519 encryption and decryption with checks for ciphertext uniqueness and validation of decryption results. [[1]](diffhunk://#diff-6caa8f42ce959bf93a99ced151207a1853619e5d15e3f85a7127806b7781f3dbR26-R34) [[2]](diffhunk://#diff-6caa8f42ce959bf93a99ced151207a1853619e5d15e3f85a7127806b7781f3dbR43-R51)

#### Code Consistency:
* `caesar/ecdsa/PublicKey.go` and `caesar/ed25519/PublicKey.go`: Updated variable names from "temporary" to "ephemeral" in `NewEnvelope` methods to maintain consistency with other changes. [[1]](diffhunk://#diff-add40044378714f7883617be42643669dda000a0fb9d72c07d03a604c8110809L26-R30) [[2]](diffhunk://#diff-77a836519bf5241d16af55dab165b9839c42b47ed08b5ab1cea0b2a54228f4c3L26-R30)