### PR TITLE
:sparkles: feat: add support for signing and verifying with version 2 in ed25519

### DIFF
--- a/caesar/ed25519/ed25519.go
+++ b/caesar/ed25519/ed25519.go
@@ -105,6 +105,8 @@ func Sign(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte, e
 	switch version {
 	case "1":
 		return signV1(version, prvKey, message)
+	case "2":
+		return signV2(version, prvKey, message)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
@@ -116,7 +118,15 @@ func signV1(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte,
 	// In the case of ed25519, hashing before signing/verifying is not required,
 	// but it is done for backwards compatibility.
 	hash := sha256.Sum256(message)
+
 	sig := ed25519.Sign(*prvKey, hash[:])
+	return sig, nil
+}
+
+func signV2(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte, error) {
+	_ = version // unused parameter
+
+	sig := ed25519.Sign(*prvKey, message)
 	return sig, nil
 }
 
@@ -125,6 +135,8 @@ func Verify(version string, pubKey *ed25519.PublicKey, message, sig []byte) bool
 	switch version {
 	case "1":
 		return verifyV1(version, pubKey, message, sig)
+	case "2":
+		return verifyV2(version, pubKey, message, sig)
 	default:
 		return false // unknown version
 	}
@@ -136,5 +148,12 @@ func verifyV1(version string, pubKey *ed25519.PublicKey, message, sig []byte) bo
 	// In the case of ed25519, hashing before signing/verifying is not required,
 	// but it is done for backwards compatibility.
 	hash := sha256.Sum256(message)
+
 	return ed25519.Verify(*pubKey, hash[:], sig)
+}
+
+func verifyV2(version string, pubKey *ed25519.PublicKey, message, sig []byte) bool {
+	_ = version // unused parameter
+
+	return ed25519.Verify(*pubKey, message, sig)
 }

--- a/caesar/ed25519/ed25519.go
+++ b/caesar/ed25519/ed25519.go
@@ -104,17 +104,15 @@ func exchangeKey(xPrvKey *ecdh.PrivateKey, xPubKey *ecdh.PublicKey) ([]byte, err
 func Sign(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte, error) {
 	switch version {
 	case "1":
-		return signV1(version, prvKey, message)
+		return signV1(prvKey, message)
 	case "2":
-		return signV2(version, prvKey, message)
+		return signV2(prvKey, message)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
 }
 
-func signV1(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte, error) {
-	_ = version // unused parameter
-
+func signV1(prvKey *ed25519.PrivateKey, message []byte) ([]byte, error) {
 	// In the case of ed25519, hashing before signing/verifying is not required,
 	// but it is done for backwards compatibility.
 	hash := sha256.Sum256(message)
@@ -123,9 +121,7 @@ func signV1(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte,
 	return sig, nil
 }
 
-func signV2(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte, error) {
-	_ = version // unused parameter
-
+func signV2(prvKey *ed25519.PrivateKey, message []byte) ([]byte, error) {
 	sig := ed25519.Sign(*prvKey, message)
 	return sig, nil
 }
@@ -134,17 +130,15 @@ func signV2(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte,
 func Verify(version string, pubKey *ed25519.PublicKey, message, sig []byte) bool {
 	switch version {
 	case "1":
-		return verifyV1(version, pubKey, message, sig)
+		return verifyV1(pubKey, message, sig)
 	case "2":
-		return verifyV2(version, pubKey, message, sig)
+		return verifyV2(pubKey, message, sig)
 	default:
 		return false // unknown version
 	}
 }
 
-func verifyV1(version string, pubKey *ed25519.PublicKey, message, sig []byte) bool {
-	_ = version // unused parameter
-
+func verifyV1(pubKey *ed25519.PublicKey, message, sig []byte) bool {
 	// In the case of ed25519, hashing before signing/verifying is not required,
 	// but it is done for backwards compatibility.
 	hash := sha256.Sum256(message)
@@ -152,8 +146,6 @@ func verifyV1(version string, pubKey *ed25519.PublicKey, message, sig []byte) bo
 	return ed25519.Verify(*pubKey, hash[:], sig)
 }
 
-func verifyV2(version string, pubKey *ed25519.PublicKey, message, sig []byte) bool {
-	_ = version // unused parameter
-
+func verifyV2(pubKey *ed25519.PublicKey, message, sig []byte) bool {
 	return ed25519.Verify(*pubKey, message, sig)
 }

--- a/caesar/ed25519/ed25519_test.go
+++ b/caesar/ed25519/ed25519_test.go
@@ -68,6 +68,23 @@ func Test_Sign_Verify_V1(t *testing.T) {
 	}
 }
 
+func Test_Sign_Verify_V2(t *testing.T) {
+	message := []byte("hello world --------------- 0521")
+	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sig, err := Sign("2", &prvKey, message)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !Verify("2", &pubKey, message, sig) {
+		t.Fatal("verify failed")
+	}
+}
+
 func Test_NewEnvelope_ExtractShareKey_V1(t *testing.T) {
 	message := []byte("hello world --------------- 1024") // 32byte
 
@@ -120,6 +137,32 @@ func Test_PrivateKeySign_PublickKeyVerify_V1(t *testing.T) {
 	}
 
 	if !ed25519PubKey.Verify("1", message, sig) {
+		t.Fatal("verify failed")
+	}
+}
+
+func Test_PrivateKeySign_PublickKeyVerify_V2(t *testing.T) {
+	message := []byte("hello world --------------- 1024") // 32byte
+
+	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sshPubKey, err := ssh.NewPublicKey(pubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ed25519PrvKey := NewPrivateKey(prvKey)
+	ed25519PubKey := NewPublicKey(pubKey, sshPubKey)
+
+	sig, err := ed25519PrvKey.Sign("2", message)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !ed25519PubKey.Verify("2", message, sig) {
 		t.Fatal("verify failed")
 	}
 }

--- a/caesar/ed25519/ed25519_test.go
+++ b/caesar/ed25519/ed25519_test.go
@@ -115,7 +115,7 @@ func Test_NewEnvelope_ExtractShareKey_V1(t *testing.T) {
 	}
 }
 
-func Test_PrivateKeySign_PublickKeyVerify_V1(t *testing.T) {
+func Test_PrivateKeySign_PublicKeyVerify_V1(t *testing.T) {
 	message := []byte("hello world --------------- 1024") // 32byte
 
 	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
@@ -141,7 +141,7 @@ func Test_PrivateKeySign_PublickKeyVerify_V1(t *testing.T) {
 	}
 }
 
-func Test_PrivateKeySign_PublickKeyVerify_V2(t *testing.T) {
+func Test_PrivateKeySign_PublicKeyVerify_V2(t *testing.T) {
 	message := []byte("hello world --------------- 1024") // 32byte
 
 	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)


### PR DESCRIPTION
This pull request introduces support for a new signing and verification version (`version "2"`) in the `ed25519` module. It includes updates to the signing and verification logic, as well as new test cases to ensure functionality for the new version.

### Updates to signing and verification logic:

* Added support for `version "2"` in the `Sign` and `Verify` functions, which directly signs and verifies the raw message without hashing it first. (`caesar/ed25519/ed25519.go`, [[1]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R108-R109) [[2]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R151-R159)
* Implemented `signV2` and `verifyV2` helper functions to handle the signing and verification logic for `version "2"`. (`caesar/ed25519/ed25519.go`, [[1]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R121-R139) [[2]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R151-R159)

### Test cases for version "2":

* Added `Test_Sign_Verify_V2` to validate the signing and verification process for `version "2"`. (`caesar/ed25519/ed25519_test.go`, [caesar/ed25519/ed25519_test.goR71-R87](diffhunk://#diff-6caa8f42ce959bf93a99ced151207a1853619e5d15e3f85a7127806b7781f3dbR71-R87))
* Added `Test_PrivateKeySign_PublickKeyVerify_V2` to test the integration of private key signing and public key verification for `version "2"`. (`caesar/ed25519/ed25519_test.go`, [caesar/ed25519/ed25519_test.goR143-R168](diffhunk://#diff-6caa8f42ce959bf93a99ced151207a1853619e5d15e3f85a7127806b7781f3dbR143-R168))