### PR TITLE
Refactor: Extract file format version to constant and remove unused version arguments

### DIFF
--- a/caesar/aes/aes.go
+++ b/caesar/aes/aes.go
@@ -6,12 +6,14 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"fmt"
+
+	"github.com/yoshi389111/git-caesar/caesar/common"
 )
 
 // Encrypt encrypts a message using AES-256.
 func Encrypt(version string, key, plaintext []byte) ([]byte, error) {
 	switch version {
-	case "1":
+	case common.Version1:
 		return encryptV1(version, key, plaintext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -50,7 +52,7 @@ func encryptV1(version string, key, plaintext []byte) ([]byte, error) {
 // Decrypt decrypts a message using AES-256.
 func Decrypt(version string, key, ciphertext []byte) ([]byte, error) {
 	switch version {
-	case "1":
+	case common.Version1:
 		return decryptV1(version, key, ciphertext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)

--- a/caesar/aes/aes.go
+++ b/caesar/aes/aes.go
@@ -14,15 +14,14 @@ import (
 func Encrypt(version string, key, plaintext []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
-		return encryptV1(version, key, plaintext)
+		return encryptV1(key, plaintext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
 }
 
 // Encrypt encrypts a message using AES-256-CBC with PKCS#7 padding.
-func encryptV1(version string, key, plaintext []byte) ([]byte, error) {
-	_ = version // unused parameter
+func encryptV1(key, plaintext []byte) ([]byte, error) {
 
 	// pad the message with PKCS#7
 	padding := aes.BlockSize - len(plaintext)%aes.BlockSize
@@ -53,15 +52,14 @@ func encryptV1(version string, key, plaintext []byte) ([]byte, error) {
 func Decrypt(version string, key, ciphertext []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
-		return decryptV1(version, key, ciphertext)
+		return decryptV1(key, ciphertext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
 }
 
 // Decrypt decrypts a message using AES-256-CBC with PKCS#7 padding.
-func decryptV1(version string, key, ciphertext []byte) ([]byte, error) {
-	_ = version // unused parameter
+func decryptV1(key, ciphertext []byte) ([]byte, error) {
 
 	// Check if ciphertext is long enough to contain an IV
 	if len(ciphertext) < aes.BlockSize {

--- a/caesar/common/versions.go
+++ b/caesar/common/versions.go
@@ -1,0 +1,8 @@
+package common
+
+const (
+	// Version1 is the first version of caesar.json format.
+	Version1 string = "1"
+	// Version2 is the second version of caesar.json format.
+	Version2 string = "2"
+)

--- a/caesar/ecdsa/ecdsa.go
+++ b/caesar/ecdsa/ecdsa.go
@@ -107,15 +107,13 @@ func decryptV1(version string, prvKey *ecdsa.PrivateKey, peersPubKey *ecdsa.Publ
 func Sign(version string, prvKey *ecdsa.PrivateKey, message []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
-		return signV1(version, prvKey, message)
+		return signV1(prvKey, message)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
 }
 
-func signV1(version string, prvKey *ecdsa.PrivateKey, message []byte) ([]byte, error) {
-	_ = version // unused parameter
-
+func signV1(prvKey *ecdsa.PrivateKey, message []byte) ([]byte, error) {
 	hash := sha256.Sum256(message)
 	sig, err := ecdsa.SignASN1(rand.Reader, prvKey, hash[:])
 	if err != nil {
@@ -128,15 +126,13 @@ func signV1(version string, prvKey *ecdsa.PrivateKey, message []byte) ([]byte, e
 func Verify(version string, pubKey *ecdsa.PublicKey, message, sig []byte) bool {
 	switch version {
 	case common.Version1:
-		return verifyV1(version, pubKey, message, sig)
+		return verifyV1(pubKey, message, sig)
 	default:
 		return false // unknown version
 	}
 }
 
-func verifyV1(version string, pubKey *ecdsa.PublicKey, message, sig []byte) bool {
-	_ = version // unused parameter
-
+func verifyV1(pubKey *ecdsa.PublicKey, message, sig []byte) bool {
 	hash := sha256.Sum256(message)
 	return ecdsa.VerifyASN1(pubKey, hash[:], sig)
 }

--- a/caesar/ecdsa/ecdsa.go
+++ b/caesar/ecdsa/ecdsa.go
@@ -8,12 +8,13 @@ import (
 	"math/big"
 
 	"github.com/yoshi389111/git-caesar/caesar/aes"
+	"github.com/yoshi389111/git-caesar/caesar/common"
 )
 
 // Encrypt encrypts a message using ECDH key exchange and AES-256.
 func Encrypt(version string, peersPubKey *ecdsa.PublicKey, message []byte) ([]byte, *ecdsa.PublicKey, error) {
 	switch version {
-	case "1":
+	case common.Version1:
 		return encryptV1(version, peersPubKey, message)
 	default:
 		return nil, nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -65,7 +66,7 @@ func encryptV1(version string, peersPubKey *ecdsa.PublicKey, message []byte) ([]
 // Decrypt decrypts a message using ECDH key exchange and AES-256.
 func Decrypt(version string, prvKey *ecdsa.PrivateKey, peersPubKey *ecdsa.PublicKey, ciphertext []byte) ([]byte, error) {
 	switch version {
-	case "1":
+	case common.Version1:
 		return decryptV1(version, prvKey, peersPubKey, ciphertext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -105,7 +106,7 @@ func decryptV1(version string, prvKey *ecdsa.PrivateKey, peersPubKey *ecdsa.Publ
 // Sign creates an ECDSA signature for the given message.
 func Sign(version string, prvKey *ecdsa.PrivateKey, message []byte) ([]byte, error) {
 	switch version {
-	case "1":
+	case common.Version1:
 		return signV1(version, prvKey, message)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -126,7 +127,7 @@ func signV1(version string, prvKey *ecdsa.PrivateKey, message []byte) ([]byte, e
 // Verify checks an ECDSA signature for the given message.
 func Verify(version string, pubKey *ecdsa.PublicKey, message, sig []byte) bool {
 	switch version {
-	case "1":
+	case common.Version1:
 		return verifyV1(version, pubKey, message, sig)
 	default:
 		return false // unknown version

--- a/caesar/ed25519/ed25519.go
+++ b/caesar/ed25519/ed25519.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 
 	"github.com/yoshi389111/git-caesar/caesar/aes"
+	"github.com/yoshi389111/git-caesar/caesar/common"
 )
 
 // Encrypt encrypts a message using X25519 key exchange and AES-256-CBC.
 func Encrypt(version string, otherPubKey *ed25519.PublicKey, message []byte) ([]byte, *ed25519.PublicKey, error) {
 	switch version {
-	case "1":
+	case common.Version1:
 		return encryptV1(version, otherPubKey, message)
 	default:
 		return nil, nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -56,7 +57,7 @@ func encryptV1(version string, otherPubKey *ed25519.PublicKey, message []byte) (
 // Decrypt decrypts a message using X25519 key exchange and AES-256-CBC.
 func Decrypt(version string, prvKey *ed25519.PrivateKey, otherPubKey *ed25519.PublicKey, ciphertext []byte) ([]byte, error) {
 	switch version {
-	case "1":
+	case common.Version1:
 		return decryptV1(version, prvKey, otherPubKey, ciphertext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -103,9 +104,9 @@ func exchangeKey(xPrvKey *ecdh.PrivateKey, xPubKey *ecdh.PublicKey) ([]byte, err
 // Sign creates a signature for the given message using the provided private key.
 func Sign(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte, error) {
 	switch version {
-	case "1":
+	case common.Version1:
 		return signV1(prvKey, message)
-	case "2":
+	case common.Version2:
 		return signV2(prvKey, message)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -129,9 +130,9 @@ func signV2(prvKey *ed25519.PrivateKey, message []byte) ([]byte, error) {
 // Verify checks if the signature is valid for the given message and public key.
 func Verify(version string, pubKey *ed25519.PublicKey, message, sig []byte) bool {
 	switch version {
-	case "1":
+	case common.Version1:
 		return verifyV1(pubKey, message, sig)
-	case "2":
+	case common.Version2:
 		return verifyV2(pubKey, message, sig)
 	default:
 		return false // unknown version

--- a/caesar/rsa/rsa.go
+++ b/caesar/rsa/rsa.go
@@ -6,12 +6,14 @@ import (
 	"crypto/rsa"
 	"crypto/sha256"
 	"fmt"
+
+	"github.com/yoshi389111/git-caesar/caesar/common"
 )
 
 // Encrypt encrypts a message using RSA OAEP with SHA-256.
 func Encrypt(version string, pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
 	switch version {
-	case "1":
+	case common.Version1:
 		return encryptV1(version, pubKey, plaintext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -27,7 +29,7 @@ func encryptV1(version string, pubKey *rsa.PublicKey, plaintext []byte) ([]byte,
 // Decrypt decrypts a message using RSA OAEP with SHA-256.
 func Decrypt(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
 	switch version {
-	case "1":
+	case common.Version1:
 		return decryptV1(version, prvKey, ciphertext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -43,7 +45,7 @@ func decryptV1(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byt
 // Sign signs a message using RSA PKCS#1 v1.5 with SHA-256.
 func Sign(version string, prvKey *rsa.PrivateKey, message []byte) ([]byte, error) {
 	switch version {
-	case "1":
+	case common.Version1:
 		return signV1(version, prvKey, message)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -60,7 +62,7 @@ func signV1(version string, prvKey *rsa.PrivateKey, message []byte) ([]byte, err
 // Verify verifies a signature using RSA PKCS#1 v1.5 with SHA-256.
 func Verify(version string, pubKey *rsa.PublicKey, message, sig []byte) bool {
 	switch version {
-	case "1":
+	case common.Version1:
 		return verifyV1(version, pubKey, message, sig)
 	default:
 		return false // unknown version

--- a/caesar/rsa/rsa.go
+++ b/caesar/rsa/rsa.go
@@ -14,15 +14,13 @@ import (
 func Encrypt(version string, pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
-		return encryptV1(version, pubKey, plaintext)
+		return encryptV1(pubKey, plaintext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
 }
 
-func encryptV1(version string, pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
-	_ = version // unused parameter
-
+func encryptV1(pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
 	return rsa.EncryptOAEP(sha256.New(), rand.Reader, pubKey, plaintext, []byte{})
 }
 
@@ -30,15 +28,13 @@ func encryptV1(version string, pubKey *rsa.PublicKey, plaintext []byte) ([]byte,
 func Decrypt(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
-		return decryptV1(version, prvKey, ciphertext)
+		return decryptV1(prvKey, ciphertext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
 }
 
-func decryptV1(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
-	_ = version // unused parameter
-
+func decryptV1(prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
 	return rsa.DecryptOAEP(sha256.New(), rand.Reader, prvKey, ciphertext, []byte{})
 }
 
@@ -46,15 +42,13 @@ func decryptV1(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byt
 func Sign(version string, prvKey *rsa.PrivateKey, message []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
-		return signV1(version, prvKey, message)
+		return signV1(prvKey, message)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
 }
 
-func signV1(version string, prvKey *rsa.PrivateKey, message []byte) ([]byte, error) {
-	_ = version // unused parameter
-
+func signV1(prvKey *rsa.PrivateKey, message []byte) ([]byte, error) {
 	hash := sha256.Sum256(message)
 	return rsa.SignPKCS1v15(nil, prvKey, crypto.SHA256, hash[:])
 }
@@ -63,15 +57,13 @@ func signV1(version string, prvKey *rsa.PrivateKey, message []byte) ([]byte, err
 func Verify(version string, pubKey *rsa.PublicKey, message, sig []byte) bool {
 	switch version {
 	case common.Version1:
-		return verifyV1(version, pubKey, message, sig)
+		return verifyV1(pubKey, message, sig)
 	default:
 		return false // unknown version
 	}
 }
 
-func verifyV1(version string, pubKey *rsa.PublicKey, message, sig []byte) bool {
-	_ = version // unused parameter
-
+func verifyV1(pubKey *rsa.PublicKey, message, sig []byte) bool {
 	hash := sha256.Sum256(message)
 	err := rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, hash[:], sig)
 	return err == nil

--- a/getOpts.go
+++ b/getOpts.go
@@ -8,11 +8,15 @@ import (
 	"runtime/debug"
 
 	flags "github.com/jessevdk/go-flags"
+
+	"github.com/yoshi389111/git-caesar/caesar/common"
 )
 
 type VersionType string
 
-var caesarJsonVersions = []VersionType{"1"}
+var caesarJsonVersions = []VersionType{
+	VersionType(common.Version1),
+}
 
 func IsValidCaesarJsonVersion(v string) bool {
 	for _, allowed := range caesarJsonVersions {


### PR DESCRIPTION
This pull request introduces a refactor to centralize version constants for the `caesar.json` format and simplify code by removing unused parameters from cryptographic functions across multiple files. The most important changes include defining version constants in a new `common` package, updating cryptographic function implementations to use these constants, and removing redundant function parameters.

### Centralization of version constants:
* [`caesar/common/versions.go`](diffhunk://#diff-ff0163bc24e34fe4abc63cd4a6540f5f6be9e2b03bdd29b07f99fa19d47440efR1-R8): Added a new `common` package containing constants `Version1` and `Version2` to represent supported `caesar.json` versions.

### Refactoring cryptographic functions:
* [`caesar/aes/aes.go`](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358R9-R24): Updated AES encryption and decryption functions to use `common.Version1` and removed the unused `version` parameter from `encryptV1` and `decryptV1`. [[1]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358R9-R24) [[2]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358L53-R62)
* [`caesar/ecdsa/ecdsa.go`](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941R11-R17): Updated ECDSA encryption, decryption, signing, and verification functions to use `common.Version1` and removed the unused `version` parameter from corresponding `V1` functions. [[1]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941R11-R17) [[2]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L68-R69) [[3]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L108-R116) [[4]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L129-R135)
* [`caesar/ed25519/ed25519.go`](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R11-R17): Updated Ed25519 encryption, decryption, signing, and verification functions to use `common.Version1` and `common.Version2`. Removed the unused `version` parameter from `V1` functions. [[1]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464R11-R17) [[2]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464L59-R60) [[3]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464L106-R109) [[4]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464L132-R135)
* [`caesar/rsa/rsa.go`](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R9-R66): Updated RSA encryption, decryption, signing, and verification functions to use `common.Version1` and removed the unused `version` parameter from corresponding `V1` functions.

### Integration of version constants in validation:
* [`getOpts.go`](diffhunk://#diff-77f2fc53f4187fab5449cb792d06731b8e7c22d04584709822cb7e6519036691R11-R19): Refactored `caesarJsonVersions` to use `common.Version1` for validating supported `caesar.json` versions.