### PR TITLE
Migrate RSA signature/verification from PKCS1v15 to PSS

### DIFF
--- a/caesar/rsa/rsa.go
+++ b/caesar/rsa/rsa.go
@@ -10,11 +10,17 @@ import (
 	"github.com/yoshi389111/git-caesar/caesar/common"
 )
 
+const (
+	LabelV2 = "git-caesar/rsa-encrypt/v2"
+)
+
 // Encrypt encrypts a message using RSA OAEP with SHA-256.
 func Encrypt(version string, pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
 		return encryptV1(pubKey, plaintext)
+	case common.Version2:
+		return encryptV2(pubKey, plaintext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
@@ -24,11 +30,17 @@ func encryptV1(pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
 	return rsa.EncryptOAEP(sha256.New(), rand.Reader, pubKey, plaintext, []byte{})
 }
 
+func encryptV2(pubKey *rsa.PublicKey, plaintext []byte) ([]byte, error) {
+	return rsa.EncryptOAEP(sha256.New(), rand.Reader, pubKey, plaintext, []byte(LabelV2))
+}
+
 // Decrypt decrypts a message using RSA OAEP with SHA-256.
 func Decrypt(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
 		return decryptV1(prvKey, ciphertext)
+	case common.Version2:
+		return decryptV2(prvKey, ciphertext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
@@ -36,6 +48,10 @@ func Decrypt(version string, prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte,
 
 func decryptV1(prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
 	return rsa.DecryptOAEP(sha256.New(), rand.Reader, prvKey, ciphertext, []byte{})
+}
+
+func decryptV2(prvKey *rsa.PrivateKey, ciphertext []byte) ([]byte, error) {
+	return rsa.DecryptOAEP(sha256.New(), rand.Reader, prvKey, ciphertext, []byte(LabelV2))
 }
 
 // Sign signs a message using RSA.

--- a/caesar/rsa/rsa_test.go
+++ b/caesar/rsa/rsa_test.go
@@ -100,6 +100,24 @@ func Test_SignVerifyRsa_V1(t *testing.T) {
 	}
 }
 
+func Test_SignVerifyRsa_V2(t *testing.T) {
+	message := []byte("hello world --------------- 0521")
+	prvKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubKey := &prvKey.PublicKey
+
+	sig, err := Sign("2", prvKey, message)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !Verify("2", pubKey, message, sig) {
+		t.Fatal("verify failed")
+	}
+}
+
 func Test_NewEnvelope_ExtractShareKey_V1(t *testing.T) {
 	message := []byte("hello world --------------- 1024") // 32byte
 
@@ -154,6 +172,33 @@ func Test_PrivateKeySign_PublickKeyVerify_V1(t *testing.T) {
 	}
 
 	if !rsaPubKey.Verify("1", message, sig) {
+		t.Fatal("verify failed")
+	}
+}
+
+func Test_PrivateKeySign_PublickKeyVerify_V2(t *testing.T) {
+	message := []byte("hello world --------------- 1024") // 32byte
+
+	prvKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubKey := &prvKey.PublicKey
+
+	sshPubKey, err := ssh.NewPublicKey(pubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rsaPrvKey := NewPrivateKey(*prvKey)
+	rsaPubKey := NewPublicKey(*pubKey, sshPubKey)
+
+	sig, err := rsaPrvKey.Sign("2", message)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !rsaPubKey.Verify("2", message, sig) {
 		t.Fatal("verify failed")
 	}
 }

--- a/caesar/rsa/rsa_test.go
+++ b/caesar/rsa/rsa_test.go
@@ -40,7 +40,7 @@ func Test_EncryptDecryptRsa(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
+			// RSA encryption should produce non-deterministic ciphertexts due to random padding.
 			if bytes.Equal(ciphertext, ciphertext2) {
 				t.Fatal("ciphertext should not be equal, but they are")
 			}


### PR DESCRIPTION
This pull request introduces RSA encryption, decryption, signing, and verification support for a new format version (`Version2`) in the `caesar/rsa` package, along with comprehensive test coverage for the new functionality. The changes include adding new methods for handling `Version2`, updating existing methods to support multiple versions, and significantly expanding the test suite to ensure correctness across different key lengths, versions, and scenarios.

### RSA Functionality Enhancements:
* **Added support for `Version2` encryption and decryption**:
  - Introduced the `LabelV2` constant for RSA OAEP padding in `encryptV2` and `decryptV2` methods. [[1]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R13-R23) [[2]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R33-R43) [[3]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67L41-R63)
* **Added support for `Version2` signing and verification**:
  - Implemented `signV2` using RSA PSS for signing and `verifyV2` for verification. [[1]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67L56-R85) [[2]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R96-R101)

### Test Suite Expansion:
* **Refactored and expanded encryption/decryption tests**:
  - Consolidated tests into a single `Test_EncryptDecryptRsa` function with cases for various key lengths and format versions. Added tests for invalid versions and mismatched keys.
* **Refactored and expanded signing/verification tests**:
  - Added `Test_SignVerifyRsa` and other tests to cover scenarios like invalid versions, mismatched keys, and modified messages.

These changes ensure robust support for the new format version while maintaining backward compatibility with `Version1`.