### PR TITLE
:sparkles: feat: add AES-GCM encryption and decryption support for version 2

### DIFF
--- a/caesar/aes/aes.go
+++ b/caesar/aes/aes.go
@@ -6,21 +6,24 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"fmt"
+	"io"
 
 	"github.com/yoshi389111/git-caesar/caesar/common"
 )
 
-// Encrypt encrypts a message using AES-256.
+// Encrypt encrypts a message using AES.
 func Encrypt(version string, key, plaintext []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
 		return encryptV1(key, plaintext)
+	case common.Version2:
+		return encryptV2(key, plaintext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
 }
 
-// Encrypt encrypts a message using AES-256-CBC with PKCS#7 padding.
+// Encrypt encrypts a message using AES-CBC with PKCS#7 padding.
 func encryptV1(key, plaintext []byte) ([]byte, error) {
 
 	// pad the message with PKCS#7
@@ -48,17 +51,43 @@ func encryptV1(key, plaintext []byte) ([]byte, error) {
 	return ciphertext, nil
 }
 
-// Decrypt decrypts a message using AES-256.
+// Encrypt encrypts a message using AES-GCM.
+func encryptV2(key, plaintext []byte) ([]byte, error) {
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher block for encryption: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM mode: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nil, nonce, plaintext, nil)
+	ciphertext = append(nonce, ciphertext...)
+
+	return ciphertext, nil
+}
+
+// Decrypt decrypts a message using AES.
 func Decrypt(version string, key, ciphertext []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
 		return decryptV1(key, ciphertext)
+	case common.Version2:
+		return decryptV2(key, ciphertext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
 }
 
-// Decrypt decrypts a message using AES-256-CBC with PKCS#7 padding.
+// Decrypt decrypts a message using AES-CBC with PKCS#7 padding.
 func decryptV1(key, ciphertext []byte) ([]byte, error) {
 
 	// Check if ciphertext is long enough to contain an IV
@@ -100,5 +129,34 @@ func decryptV1(key, ciphertext []byte) ([]byte, error) {
 		}
 	}
 	plaintext := decMsg[:msgLen-padding]
+	return plaintext, nil
+}
+
+// Decrypt decrypts a message using AES-GCM.
+func decryptV2(key, ciphertext []byte) ([]byte, error) {
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher block for encryption: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM mode: %w", err)
+	}
+
+	if len(ciphertext) < gcm.NonceSize() {
+		return nil, fmt.Errorf("ciphertext too short")
+	}
+
+	nonce := ciphertext[:gcm.NonceSize()]
+	encMsg := ciphertext[gcm.NonceSize():]
+
+	// Decrypt the ciphertext
+	plaintext, err := gcm.Open(nil, nonce, encMsg, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt ciphertext: %w", err)
+	}
+
 	return plaintext, nil
 }

--- a/caesar/aes/aes.go
+++ b/caesar/aes/aes.go
@@ -137,7 +137,7 @@ func decryptV2(key, ciphertext []byte) ([]byte, error) {
 
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create AES cipher block for encryption: %w", err)
+		return nil, fmt.Errorf("failed to create AES cipher block for decryption: %w", err)
 	}
 
 	gcm, err := cipher.NewGCM(block)

--- a/caesar/aes/aes_test.go
+++ b/caesar/aes/aes_test.go
@@ -7,128 +7,122 @@ import (
 	"testing"
 )
 
-func Test_Encrypt_Decrypt_AesCbc32_V1(t *testing.T) {
-	message := []byte("hello world AES-256-CBC")
+func Test_Encrypt_Decrypt_Aes(t *testing.T) {
+	cases := map[string]struct {
+		keyLength     int
+		formatVersion string
+	}{
+		"aes256_formatVer1": {32, "1"},
 
+		"aes128_formatVer2": {16, "2"},
+		"aes192_formatVer2": {24, "2"},
+		"aes256_formatVer2": {32, "2"},
+	}
+
+	message := []byte("hello world AES encryption test")
+	for name, tc := range cases {
+		t.Run("Encrypt_Decrypt_"+name, func(t *testing.T) {
+			key := make([]byte, tc.keyLength)
+			_, err := rand.Read(key)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ciphertext, err := Encrypt(tc.formatVersion, key, []byte(message))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ciphertext2, err := Encrypt(tc.formatVersion, key, []byte(message))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// AES encryption should produce non-deterministic ciphertexts due to random padding.
+			if bytes.Equal(ciphertext, ciphertext2) {
+				t.Fatal("ciphertext should not be equal, but they are")
+			}
+
+			plaintext, err := Decrypt(tc.formatVersion, key, ciphertext)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(message, plaintext) {
+				t.Fatal(hex.Dump(plaintext))
+			}
+
+			plaintext2, err := Decrypt(tc.formatVersion, key, ciphertext2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(message, plaintext2) {
+				t.Fatal(hex.Dump(plaintext2))
+			}
+		})
+	}
+}
+
+func Test_EncryptDecrypt_Aes_InvalidVersion(t *testing.T) {
 	key := make([]byte, 32)
-	_, err := rand.Read(key)
-	if err != nil {
+
+	if _, err := rand.Read(key); err != nil {
 		t.Fatal(err)
 	}
+	octetStream := []byte("test message")
 
-	ciphertext, err := Encrypt("1", key, []byte(message))
-	if err != nil {
-		t.Fatal(err)
+	if _, err := Encrypt("invalid", key, octetStream); err == nil {
+		t.Fatal("expected encryption to fail with invalid version, but it succeeded")
 	}
 
-	ciphertext2, err := Encrypt("1", key, []byte(message))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if bytes.Equal(ciphertext, ciphertext2) {
-		t.Fatal("ciphertexts should not be equal")
-	}
-
-	plaintext, err := Decrypt("1", key, ciphertext)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(message, plaintext) {
-		t.Fatal(hex.Dump(plaintext))
-	}
-
-	plaintext2, err := Decrypt("1", key, ciphertext2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(message, plaintext2) {
-		t.Fatal(hex.Dump(plaintext2))
+	if _, err := Decrypt("invalid", key, octetStream); err == nil {
+		t.Fatal("expected decryption to fail with invalid version, but it succeeded")
 	}
 }
 
-func Test_Encrypt_Decrypt_AesCbc24_V1(t *testing.T) {
-	message := []byte("hello world AES-192-CBC")
+func Test_Encrypt_Decrypt_Aes_WrongKey(t *testing.T) {
+	cases := map[string]struct {
+		keyLength     int
+		formatVersion string
+	}{
+		"aes256_formatVer1": {32, "1"},
 
-	key := make([]byte, 24)
-	_, err := rand.Read(key)
-	if err != nil {
-		t.Fatal(err)
+		"aes128_formatVer2": {16, "2"},
+		"aes192_formatVer2": {24, "2"},
+		"aes256_formatVer2": {32, "2"},
 	}
 
-	ciphertext, err := Encrypt("1", key, []byte(message))
-	if err != nil {
-		t.Fatal(err)
-	}
+	message := []byte("hello world AES wrong key test")
+	for name, tc := range cases {
+		t.Run("Encrypt_Decrypt_WrongKey_"+name, func(t *testing.T) {
+			key1 := make([]byte, tc.keyLength)
+			if _, err := rand.Read(key1); err != nil {
+				t.Fatal(err)
+			}
 
-	ciphertext2, err := Encrypt("1", key, []byte(message))
-	if err != nil {
-		t.Fatal(err)
-	}
+			key2 := make([]byte, tc.keyLength)
+			if _, err := rand.Read(key2); err != nil {
+				t.Fatal(err)
+			}
 
-	if bytes.Equal(ciphertext, ciphertext2) {
-		t.Fatal("ciphertexts should not be equal")
-	}
+			ciphertext, err := Encrypt(tc.formatVersion, key1, []byte(message))
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	plaintext, err := Decrypt("1", key, ciphertext)
-	if err != nil {
-		t.Fatal(err)
-	}
+			ciphertext2, err := Encrypt(tc.formatVersion, key2, []byte(message))
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	if !bytes.Equal(message, plaintext) {
-		t.Fatal(hex.Dump(plaintext))
-	}
+			if _, err = Decrypt(tc.formatVersion, key2, ciphertext); err == nil {
+				t.Fatal("expected decryption to fail with wrong key, but it succeeded")
+			}
 
-	plaintext2, err := Decrypt("1", key, ciphertext2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(message, plaintext2) {
-		t.Fatal(hex.Dump(plaintext2))
-	}
-}
-
-func Test_Encrypt_Decrypt_AesCbc16_V1(t *testing.T) {
-	message := []byte("hello world AES-128-CBC")
-
-	key := make([]byte, 16)
-	_, err := rand.Read(key)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ciphertext, err := Encrypt("1", key, []byte(message))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ciphertext2, err := Encrypt("1", key, []byte(message))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if bytes.Equal(ciphertext, ciphertext2) {
-		t.Fatal("ciphertexts should not be equal")
-	}
-
-	plaintext, err := Decrypt("1", key, ciphertext)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(message, plaintext) {
-		t.Fatal(hex.Dump(plaintext))
-	}
-
-	plaintext2, err := Decrypt("1", key, ciphertext2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(message, plaintext2) {
-		t.Fatal(hex.Dump(plaintext2))
+			if _, err = Decrypt(tc.formatVersion, key1, ciphertext2); err == nil {
+				t.Fatal("expected decryption to fail with wrong key, but it succeeded")
+			}
+		})
 	}
 }


### PR DESCRIPTION
This pull request enhances the AES encryption and decryption functionality by introducing support for AES-GCM alongside AES-CBC, refactoring the code to accommodate multiple AES formats, and updating the test suite to ensure comprehensive coverage of the new functionality.

### Enhancements to AES encryption and decryption:

* Added support for AES-GCM encryption and decryption by introducing new methods `encryptV2` and `decryptV2`. AES-GCM provides authenticated encryption with associated data, improving security. [[1]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358L51-R90) [[2]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358R134-R162)
* Modified the `Encrypt` and `Decrypt` functions to handle multiple AES formats (`Version1` for AES-CBC and `Version2` for AES-GCM). This allows flexibility in choosing encryption modes. [[1]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358R9-R26) [[2]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358L51-R90)

### Refactoring and code improvements:

* Updated comments and method names to reflect the broader AES encryption modes (e.g., replacing "AES-256" with "AES" for generalization).
* Refactored the test suite to use table-driven tests, consolidating multiple test cases into a single function (`Test_Encrypt_Decrypt_Aes`) for better maintainability and readability. [[1]](diffhunk://#diff-8b6a05ca404546c5d76a6c96cdea82e00c1e247c6e04f8507afb4dd4498a89e4L10-R46) [[2]](diffhunk://#diff-8b6a05ca404546c5d76a6c96cdea82e00c1e247c6e04f8507afb4dd4498a89e4L42-R126)

### Test suite enhancements:

* Added new test cases to validate encryption and decryption behavior for invalid format versions and incorrect keys, ensuring robustness against edge cases.
* Expanded test coverage to include AES-GCM functionality across different key lengths (128-bit, 192-bit, and 256-bit) and format versions.