### PR TITLE
:sparkles: feat: Update README and code for ECDSA and Ed25519 encryption enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This command encrypts and decrypts files using the public key registered on GitH
 
 ### How to build with GO command
 
-Requires go 1.23.0 or higher
+Requires go 1.24.0 or higher
 
 See below for how to install/upgrade.
 

--- a/caesar/ed25519/ed25519.go
+++ b/caesar/ed25519/ed25519.go
@@ -1,8 +1,8 @@
 package ed25519
 
 import (
-	"crypto/ecdh"
 	"crypto/ed25519"
+	"crypto/hkdf"
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
@@ -11,63 +11,141 @@ import (
 	"github.com/yoshi389111/git-caesar/caesar/common"
 )
 
+const (
+	infoV2 = "git-caesar/ed25519-key-exchange/v2"
+)
+
 // Encrypt encrypts a message using X25519 key exchange and AES-256.
-func Encrypt(version string, otherPubKey *ed25519.PublicKey, message []byte) ([]byte, *ed25519.PublicKey, error) {
+func Encrypt(version string, peerPubKey *ed25519.PublicKey, message []byte) ([]byte, *ed25519.PublicKey, error) {
 	switch version {
 	case common.Version1:
-		return encryptV1(version, otherPubKey, message)
+		return encryptV1(version, peerPubKey, message)
+	case common.Version2:
+		return encryptV2(version, peerPubKey, message)
 	default:
 		return nil, nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
 }
 
-func encryptV1(version string, otherPubKey *ed25519.PublicKey, message []byte) ([]byte, *ed25519.PublicKey, error) {
+func encryptV1(version string, peerPubKey *ed25519.PublicKey, message []byte) ([]byte, *ed25519.PublicKey, error) {
 	// generate ephemeral key pair
 	ephemeralEdPubKey, ephemeralEdPrvKey, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to generate ephemeral key pair for ed25519: %w", err)
 	}
 
-	// convert ed25519 public key to x25519 public key
-	xOtherPubKey, err := toX25519PublicKey(otherPubKey)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to convert ed25519 public key to X25519 public key: %w", err)
-	}
-
-	// convert ed25519 private key to x25519 private key
-	xPrvKey, err := toX25519PrivateKey(&ephemeralEdPrvKey)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to convert ed25519 private key to X25519 private key: %w", err)
-	}
-
 	// key exchange
-	sharedKey, err := exchangeKey(xPrvKey, xOtherPubKey)
+	exchangedKey, err := exchangeKey(&ephemeralEdPrvKey, peerPubKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to X25519 key exchange: %w", err)
 	}
 
+	// When using the exchanged key as an encryption key,
+	// HKDF or similar should be used instead of SHA-2,
+	// but SHA-2 is used for backward compatibility.
+	sharedKey := sha256.Sum256(exchangedKey)
+
 	// encrypt AES-256
-	ciphertext, err := aes.Encrypt(version, sharedKey, message)
+	ciphertext, err := aes.Encrypt(version, sharedKey[:], message)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to AES encryption for ed25519: %w", err)
 	}
 	return ciphertext, &ephemeralEdPubKey, nil
 }
 
+func encryptV2(version string, peerPubKey *ed25519.PublicKey, message []byte) ([]byte, *ed25519.PublicKey, error) {
+	// generate ephemeral key pair
+	ephemeralEdPubKey, ephemeralEdPrvKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate ephemeral key pair for ed25519: %w", err)
+	}
+
+	// key exchange
+	exchangedKey, err := exchangeKey(&ephemeralEdPrvKey, peerPubKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to X25519 key exchange: %w", err)
+	}
+
+	salt := make([]byte, 32) // 32 bytes salt for HKDF
+	if _, err := rand.Read(salt); err != nil {
+		return nil, nil, fmt.Errorf("failed to generate salt for HKDF: %w", err)
+	}
+
+	sharedKey, err := hkdf.Key(sha256.New, exchangedKey, salt, infoV2, 32)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create HKDF key for ecdsa: %w", err)
+	}
+
+	// encrypt AES-256
+	ciphertext, err := aes.Encrypt(version, sharedKey[:], message)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to AES encryption for ed25519: %w", err)
+	}
+
+	// prepend salt to ciphertext
+	ciphertext = append(salt, ciphertext...)
+
+	return ciphertext, &ephemeralEdPubKey, nil
+}
+
 // Decrypt decrypts a message using X25519 key exchange and AES-256.
-func Decrypt(version string, prvKey *ed25519.PrivateKey, otherPubKey *ed25519.PublicKey, ciphertext []byte) ([]byte, error) {
+func Decrypt(version string, prvKey *ed25519.PrivateKey, peerPubKey *ed25519.PublicKey, ciphertext []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
-		return decryptV1(version, prvKey, otherPubKey, ciphertext)
+		return decryptV1(version, prvKey, peerPubKey, ciphertext)
+	case common.Version2:
+		return decryptV2(version, prvKey, peerPubKey, ciphertext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
 	}
 }
 
-func decryptV1(version string, prvKey *ed25519.PrivateKey, otherPubKey *ed25519.PublicKey, ciphertext []byte) ([]byte, error) {
+func decryptV1(version string, prvKey *ed25519.PrivateKey, peerPubKey *ed25519.PublicKey, ciphertext []byte) ([]byte, error) {
+	// key exchange
+	exchangedKey, err := exchangeKey(prvKey, peerPubKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to X25519 key exchange: %w", err)
+	}
 
+	// When using the exchanged key as an encryption key,
+	// HKDF or similar should be used instead of SHA-2,
+	// but SHA-2 is used for backward compatibility.
+	sharedKey := sha256.Sum256(exchangedKey)
+
+	// decrypt AES-256-CBC
+	return aes.Decrypt(version, sharedKey[:], ciphertext)
+}
+
+func decryptV2(version string, prvKey *ed25519.PrivateKey, peerPubKey *ed25519.PublicKey, ciphertext []byte) ([]byte, error) {
+	// key exchange
+	exchangedKey, err := exchangeKey(prvKey, peerPubKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to X25519 key exchange: %w", err)
+	}
+
+	if len(ciphertext) < 32 {
+		return nil, fmt.Errorf("ciphertext is too short for ed25519 decryption")
+	}
+
+	// extract salt from the beginning of the ciphertext
+	salt := ciphertext[:32]
+
+	// remove salt from ciphertext
+	ciphertext = ciphertext[32:]
+
+	// hash the exchanged key using HKDF
+	sharedKey, err := hkdf.Key(sha256.New, exchangedKey, salt, infoV2, 32)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HKDF key for ecdsa: %w", err)
+	}
+
+	// decrypt AES-256-GCM
+	return aes.Decrypt(version, sharedKey[:], ciphertext)
+}
+
+func exchangeKey(prvKey *ed25519.PrivateKey, pubKey *ed25519.PublicKey) ([]byte, error) {
 	// convert ed25519 public key to x25519 public key
-	xOtherPubKey, err := toX25519PublicKey(otherPubKey)
+	xPubKey, err := toX25519PublicKey(pubKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert ed25519 public key to X25519 public key: %w", err)
 	}
@@ -78,27 +156,13 @@ func decryptV1(version string, prvKey *ed25519.PrivateKey, otherPubKey *ed25519.
 		return nil, fmt.Errorf("failed to convert ed25519 private key to X25519 private key: %w", err)
 	}
 
-	// key exchange
-	sharedKey, err := exchangeKey(xPrvKey, xOtherPubKey)
-	if err != nil {
-		return nil, fmt.Errorf("failed to X25519 key exchange: %w", err)
-	}
-
-	// decrypt AES-256
-	return aes.Decrypt(version, sharedKey, ciphertext)
-}
-
-func exchangeKey(xPrvKey *ecdh.PrivateKey, xPubKey *ecdh.PublicKey) ([]byte, error) {
+	// perform key exchange
 	exchangedKey, err := xPrvKey.ECDH(xPubKey)
 	if err != nil {
 		return nil, err // don't wrap
 	}
 
-	// When using the exchanged key as an encryption key,
-	// HKDF or similar should be used instead of SHA-2,
-	// but SHA-2 is used for backward compatibility.
-	sharedKey := sha256.Sum256(exchangedKey)
-	return sharedKey[:], nil
+	return exchangedKey[:], nil
 }
 
 // Sign creates a signature for the given message using the provided private key.

--- a/caesar/ed25519/ed25519_test.go
+++ b/caesar/ed25519/ed25519_test.go
@@ -4,165 +4,164 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
-	"encoding/hex"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
 )
 
-func Test_Encrypt_Decrypt_V1(t *testing.T) {
+func Test_Encrypt_Decrypt_ed25519(t *testing.T) {
+	cases := map[string]struct {
+		formatVersion string
+	}{
+		"ed25519_formatVer1": {"1"},
+		"ed25519_formatVer2": {"2"},
+	}
+
 	message := []byte("hello world --------------- 0256") // 32byte
+	for name, tc := range cases {
+		t.Run("Encrypt_Decrypt_"+name, func(t *testing.T) {
+			bobPubKey, bobPrvKey, err := ed25519.GenerateKey(rand.Reader)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	bobPubKey, bobPrvKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
+			ciphertext, alicePubKey, err := Encrypt(tc.formatVersion, &bobPubKey, message)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	ciphertext, alicePubKey, err := Encrypt("1", &bobPubKey, message)
-	if err != nil {
-		t.Fatal(err)
-	}
+			ciphertext2, alicePubKey2, err := Encrypt(tc.formatVersion, &bobPubKey, message)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	ciphertext2, alicePubKey2, err := Encrypt("1", &bobPubKey, message)
-	if err != nil {
-		t.Fatal(err)
-	}
+			// encryption should produce non-deterministic ciphertexts due to random padding.
+			if bytes.Equal(ciphertext, ciphertext2) {
+				t.Fatal("ciphertexts should not be equal")
+			}
 
-	if bytes.Equal(ciphertext, ciphertext2) {
-		t.Fatal("ciphertexts should not be equal")
-	}
+			plaintext, err := Decrypt(tc.formatVersion, &bobPrvKey, alicePubKey, ciphertext)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	plaintext, err := Decrypt("1", &bobPrvKey, alicePubKey, ciphertext)
-	if err != nil {
-		t.Fatal(err)
-	}
+			if !bytes.Equal(message, plaintext) {
+				t.Fatalf("decrypted message mismatch:\nexpected: %x\nactual: %x", message, plaintext)
+			}
 
-	if !bytes.Equal(message, plaintext) {
-		t.Fatal(hex.Dump(plaintext))
-	}
+			plaintext2, err := Decrypt(tc.formatVersion, &bobPrvKey, alicePubKey2, ciphertext2)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	plaintext2, err := Decrypt("1", &bobPrvKey, alicePubKey2, ciphertext2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !bytes.Equal(message, plaintext2) {
-		t.Fatal(hex.Dump(plaintext2))
+			if !bytes.Equal(message, plaintext2) {
+				t.Fatalf("decrypted message mismatch:\nexpected: %x\nactual: %x", message, plaintext2)
+			}
+		})
 	}
 }
 
 func Test_Sign_Verify_V1(t *testing.T) {
+	cases := map[string]struct {
+		formatVersion string
+	}{
+		"ed25519_formatVer1": {"1"},
+		"ed25519_formatVer2": {"2"},
+	}
+
 	message := []byte("hello world --------------- 0521")
-	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
+	for name, tc := range cases {
+		t.Run("Sign_Verify_"+name, func(t *testing.T) {
+			pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	sig, err := Sign("1", &prvKey, message)
-	if err != nil {
-		t.Fatal(err)
-	}
+			sig, err := Sign(tc.formatVersion, &prvKey, message)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	if !Verify("1", &pubKey, message, sig) {
-		t.Fatal("verify failed")
-	}
-}
-
-func Test_Sign_Verify_V2(t *testing.T) {
-	message := []byte("hello world --------------- 0521")
-	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	sig, err := Sign("2", &prvKey, message)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !Verify("2", &pubKey, message, sig) {
-		t.Fatal("verify failed")
+			if !Verify(tc.formatVersion, &pubKey, message, sig) {
+				t.Fatal("verify failed")
+			}
+		})
 	}
 }
 
-func Test_NewEnvelope_ExtractShareKey_V1(t *testing.T) {
+func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
+	cases := map[string]struct {
+		formatVersion string
+	}{
+		"ed25519_formatVer1": {"1"},
+		"ed25519_formatVer2": {"2"},
+	}
+
 	message := []byte("hello world --------------- 1024") // 32byte
+	for name, tc := range cases {
+		t.Run("NewEnvelope_ExtractShareKey_"+name, func(t *testing.T) {
+			pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
+			sshPubKey, err := ssh.NewPublicKey(pubKey)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	sshPubKey, err := ssh.NewPublicKey(pubKey)
-	if err != nil {
-		t.Fatal(err)
-	}
+			ed25519PrvKey := NewPrivateKey(prvKey)
+			ed25519PubKey := NewPublicKey(pubKey, sshPubKey)
 
-	ed25519PrvKey := NewPrivateKey(prvKey)
-	ed25519PubKey := NewPublicKey(pubKey, sshPubKey)
+			addInfo, err := ed25519PubKey.NewEnvelope(tc.formatVersion, message)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	addInfo, err := ed25519PubKey.NewEnvelope("1", message)
-	if err != nil {
-		t.Fatal(err)
-	}
+			decrypted, err := ed25519PrvKey.ExtractShareKey(tc.formatVersion, addInfo)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	decrypted, err := ed25519PrvKey.ExtractShareKey("1", addInfo)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(message, decrypted) {
-		t.Fatal(hex.Dump(decrypted))
-	}
-}
-
-func Test_PrivateKeySign_PublicKeyVerify_V1(t *testing.T) {
-	message := []byte("hello world --------------- 1024") // 32byte
-
-	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	sshPubKey, err := ssh.NewPublicKey(pubKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ed25519PrvKey := NewPrivateKey(prvKey)
-	ed25519PubKey := NewPublicKey(pubKey, sshPubKey)
-
-	sig, err := ed25519PrvKey.Sign("1", message)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !ed25519PubKey.Verify("1", message, sig) {
-		t.Fatal("verify failed")
+			if !bytes.Equal(message, decrypted) {
+				t.Fatalf("decrypted message mismatch:\nexpected: %x\nactual: %x", message, decrypted)
+			}
+		})
 	}
 }
 
-func Test_PrivateKeySign_PublicKeyVerify_V2(t *testing.T) {
+func Test_PrivateKeySign_PublicKeyVerify(t *testing.T) {
+	cases := map[string]struct {
+		formatVersion string
+	}{
+		"ed25519_formatVer1": {"1"},
+		"ed25519_formatVer2": {"2"},
+	}
+
 	message := []byte("hello world --------------- 1024") // 32byte
+	for name, tc := range cases {
+		t.Run("PrivateKeySign_PublicKeyVerify_"+name, func(t *testing.T) {
+			pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	pubKey, prvKey, err := ed25519.GenerateKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
+			sshPubKey, err := ssh.NewPublicKey(pubKey)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	sshPubKey, err := ssh.NewPublicKey(pubKey)
-	if err != nil {
-		t.Fatal(err)
-	}
+			ed25519PrvKey := NewPrivateKey(prvKey)
+			ed25519PubKey := NewPublicKey(pubKey, sshPubKey)
 
-	ed25519PrvKey := NewPrivateKey(prvKey)
-	ed25519PubKey := NewPublicKey(pubKey, sshPubKey)
+			sig, err := ed25519PrvKey.Sign(tc.formatVersion, message)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	sig, err := ed25519PrvKey.Sign("2", message)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !ed25519PubKey.Verify("2", message, sig) {
-		t.Fatal("verify failed")
+			if !ed25519PubKey.Verify(tc.formatVersion, message, sig) {
+				t.Fatal("verify failed")
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/yoshi389111/git-caesar
 
-go 1.23.0
-
-toolchain go1.24.0
+go 1.24.0
 
 require golang.org/x/crypto v0.36.0
 

--- a/go.sum
+++ b/go.sum
@@ -1,17 +1,8 @@
-github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
-github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
 github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
-golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
-golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
-golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
-golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
-golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
 golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
 golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=


### PR DESCRIPTION
This pull request introduces several enhancements to the `caesar` package, focusing on extending support for ECDSA encryption and decryption, adding HKDF-based key derivation for version 2, and improving test coverage. The changes also include updates to the documentation and minor refactoring.

### ECDSA Enhancements
* Added support for ECDSA encryption and decryption using version 2, which includes HKDF-based key derivation (`infoV2`) for enhanced security. (`caesar/ecdsa/ecdsa.go`, [[1]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941R63-R114) [[2]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941R132-R181)
* Refactored key exchange functionality into a dedicated `keyExchange` method for reusability and cleaner code. (`caesar/ecdsa/ecdsa.go`, [[1]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L33-R41) [[2]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941R132-R181)

### Test Coverage Improvements
* Consolidated and expanded tests for encryption, decryption, signing, and verification across multiple ECDSA curve types (`P256`, `P384`, `P521`) and format versions (`1`, `2`). (`caesar/ecdsa/ecdsa_test.go`, [[1]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dL10-R150) [[2]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dL176-R200) [[3]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dL206-R222)
* Improved error messages in tests to provide clearer debugging information when decrypted messages mismatch. (`caesar/ecdsa/ecdsa_test.go`, [[1]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dL290-R299) [[2]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dL323-R332)

### Documentation Update
* Updated the `README.md` to specify the required Go version as `1.24.0` or higher. (`README.md`, [README.mdL9-R9](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9))

### Refactoring and Minor Changes
* Removed unused `ecdh` import and added `hkdf` import in `caesar/ed25519/ed25519.go`. (`caesar/ed25519/ed25519.go`, [caesar/ed25519/ed25519.goL4-R5](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464L4-R5))
* Introduced a constant `infoV2` for HKDF context information to ensure consistency across the implementation. (`caesar/ecdsa/ecdsa.go`, [caesar/ecdsa/ecdsa.goR15-R25](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941R15-R25))