### PR TITLE
Update default file format to 2 and revise README for v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# GIT-CAESAR
+# GIT-CAESAR(1)
 
 ## NAME
 
-**git-caesar** - Command-line tool for encrypting and decrypting files using public key cryptography
+**git-caesar** — Command-line tool for encrypting and decrypting files using public key cryptography
 
 ## SYNOPSIS
 
@@ -50,8 +50,8 @@ Encryption uses the recipient's public key. Decryption uses your private key.
 
 - `-F`, `--format-version=<version>`
   - Format version of the encrypted file.
-    Versions `1` and `2` are valid. Version `1` is deprecated.
-    Default: `2`.
+    Versions `1`, `2` and `3` are valid. Version `1` and `2` is deprecated.
+    Default: `3`.
 
 ## EXAMPLES
 
@@ -134,16 +134,39 @@ Download the file that matches your operating environment from "Releases."
 
 ### Encryption and Signature Algorithms
 
-#### Format version 2 (recommended; since v0.0.9)
+#### Format version 3 (recommended)
+
+- supported since v0.0.10
+
+| Algorithm          | Encryption/Decryption                     | Signing/Verification         |
+|--------------------|-------------------------------------------|------------------------------|
+| AES                | AES-256-GCM                               | N/A                          |
+| RSA (≤ 4096-bit)   | RSA-OAEP (SHA-256)                        | RSA-PSS (SHA-256)            |
+| RSA (> 4096-bit)   | RSA-OAEP (SHA-256)                        | RSA-PSS (SHA-512)            |
+| ECDSA/ECDH (P-256) | ECDH + HKDF-SHA-256 + AES-256-GCM         | ECDSA (SHA-256)              |
+| ECDSA/ECDH (P-384) | ECDH + HKDF-SHA-256 + AES-256-GCM         | ECDSA (SHA-384)              |
+| ECDSA/ECDH (P-521) | ECDH + HKDF-SHA-256 + AES-256-GCM         | ECDSA (SHA-512)              |
+| ED25519/X25519     | X25519 + HKDF-SHA-256 + AES-256-GCM       | ED25519 (SHA-512)            |
+
+<details>
+<summary>Old format versions</summary>
+
+#### Format version 2
+
+- supported since v0.0.9
+- deprecated since v0.0.10
 
 | Algorithm        | Encryption/Decryption                       | Signing/Verification         |
 |------------------|---------------------------------------------|------------------------------|
 | AES              | AES-256-GCM                                 | N/A                          |
 | RSA              | RSA-OAEP (SHA-256)                          | RSA-PSS (SHA-256)            |
-| ECDSA/ECDH       | ECDH + HKDF-SHA-256 + AES-256-GCM           | ECDSA (SHA-256)              |
+| ECDSA/ECDH       | ECDH + HKDF-SHA-256 + AES-256-GCM           | ECDSA (SHA-256) ⚠️           |
 | ED25519/X25519   | X25519 + HKDF-SHA-256 + AES-256-GCM         | ED25519 (SHA-512)            |
 
-#### Format version 1 (deprecated)
+#### Format version 1
+
+- supported since v0.0.1
+- deprecated since v0.0.9
 
 | Algorithm        | Encryption/Decryption                       | Signing/Verification         |
 |------------------|---------------------------------------------|------------------------------|
@@ -151,6 +174,8 @@ Download the file that matches your operating environment from "Releases."
 | RSA              | RSA-OAEP (SHA-256)                          | RSA-PKCS1-v1_5 (SHA-256)     |
 | ECDSA/ECDH       | ECDH + ⚠️SHA-256 (for key derivation) + AES-256-CBC   | ECDSA (SHA-256)   |
 | ED25519/X25519   | X25519 + ⚠️SHA-256 (for key derivation) + AES-256-CBC | ED25519 (⚠️with pre-hashed SHA-256 input) |
+
+</details>
 
 ## SECURITY
 
@@ -166,11 +191,9 @@ However, this practice has the following potential security risks:
 
 ## SEE ALSO
 
-- dev.to [Passwordless encryption with public key for GitHub](https://dev.to/yoshi389111/passwordless-encryption-with-public-key-for-github-kb6) English
-- Qiita [GitHub 用の公開鍵でパスワードレスの暗号化/復号をしてみる](https://qiita.com/yoshi389111/items/238908e1933a8a4018c6) Japanese
+- [Passwordless encryption with public key for GitHub (dev.to)](https://dev.to/yoshi389111/passwordless-encryption-with-public-key-for-github-kb6) — English article about this tool
+- [GitHub 用の公開鍵でパスワードレスの暗号化/復号をしてみる (Qiita)](https://qiita.com/yoshi389111/items/238908e1933a8a4018c6) — Japanese article about this tool
 
-## LICENSE
+## COPYRIGHT
 
-MIT License
-
-&copy; 2023 SATO, Yoshiyuki
+&copy; 2023 SATO, Yoshiyuki. MIT Licensed.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,89 @@
-# git-caesar
+# GIT-CAESAR
 
-This command encrypts and decrypts files using the public key registered on GitHub and your own private key.
+## NAME
 
-In addition to keys registered on github, you can also specify keys registered on gitlab or SSH keys in local files.
+**git-caesar** - Command-line tool for encrypting and decrypting files using public key cryptography
 
-## Installation
+## SYNOPSIS
+
+```shell
+git-caesar [OPTIONS]
+```
+
+## DESCRIPTION
+
+**git-caesar** is a command-line tool that encrypts and decrypts files using public keys registered on GitHub, GitLab, or local SSH key files.
+Encryption uses the recipient's public key. Decryption uses your private key.
+
+## OPTIONS
+
+- `-h`, `--help`
+  - Show help and exit.
+
+- `-v`, `--version`
+  - Show version and exit.
+
+- `-u`, `--public=<target>`
+  - Specify recipient's public key. Required for encryption.
+    If a GitHub username is provided, the key is fetched from
+    `https://github.com/USER_NAME.keys`.
+    If the value starts with `http:` or `https:`, the key is fetched from the web.
+    Otherwise, it is treated as a local file path.
+    Used for signature verification in decryption.
+
+- `-k`, `--private=<id_file>`
+  - Specify your SSH private key file.
+    If omitted, the tool searches `~/.ssh/id_ecdsa`, `~/.ssh/id_ed25519`, `~/.ssh/id_rsa` in that order.
+
+- `-i`, `--input=<input_file>`
+  - Path to input file.
+    For encryption, this is the plaintext file.
+    For decryption, this is the encrypted file.
+    Defaults to stdin.
+
+- `-o`, `--output=<output_file>`
+  - Path to output file.
+    Defaults to stdout.
+
+- `-d`, `--decrypt`
+  - Decrypt mode. If not specified, encrypt mode is used.
+
+- `-F`, `--format-version=<version>`
+  - Format version of the encrypted file.
+    Versions `1` and `2` are valid. Version `1` is deprecated.
+    Default: `2`.
+
+## EXAMPLES
+
+- Encrypt `secret.txt` for GitHub user `octocat` and save as `secret.zip`:
+
+    ```shell
+    git-caesar -u octocat -i secret.txt -o secret.zip
+    ```
+
+- Encrypt using a specific private key (`~/.ssh/id_secret`):
+
+    ```shell
+    git-caesar -u octocat -i secret.txt -o secret.zip -k ~/.ssh/id_secret
+    ```
+
+- Decrypt a file for GitLab user `tanuki` and save it as `secret.txt`:
+
+    ```shell
+    git-caesar -d -u https://gitlab.com/tanuki.keys -i secret.zip -o secret.txt
+    ```
+
+- Decrypt a file without signature verification:
+
+    ```shell
+    git-caesar -d -i secret.zip -o secret.txt
+    ```
+
+## INSTALLATION
 
 ### How to build with GO command
 
-Requires go 1.24.0 or higher
+Requires Go 1.24.0 or higher
 
 See below for how to install/upgrade.
 
@@ -40,119 +115,62 @@ brew uninstall yoshi389111/apps/git-caesar
 
 Download the file that matches your operating environment from "Releases."
 
-## Usage
+## SUPPORTED ALGORITHMS
 
-```txt
-Usage:
+### Supported Public Key Algorithms
 
-  git-caesar [options]
+- `ssh-rsa` (key length 1024 bits or more)
+- `ecdsa-sha2-nistp256`
+- `ecdsa-sha2-nistp384`
+- `ecdsa-sha2-nistp521`
+- `ssh-ed25519`
 
-Application Options:
+**Unsupported:**
 
-  -h, --help                        print help and exit.
-  -v, --version                     print version and exit.
-  -u, --public=<target>             github account, url or file.
-  -k, --private=<id_file>           ssh private key file.
-  -i, --input=<input_file>          the path of the file to read. default: stdin
-  -o, --output=<output_file>        the path of the file to write. default: stdout
-  -d, --decrypt                     decryption mode.
-  -F, --format-version=<version>    format version of the encrypted file. (default: 2)
-```
+- `ssh-dss` (DSA)
+- `ssh-rsa` (key length less than 1024 bits)
+- `sk-ecdsa-sha2-nistp256@openssh.com`
+- `sk-ssh-ed25519@openssh.com`
 
-* `-u` specifies the location of the peer's public key. Get from `https://github.com/USER_NAME.keys` if the one specified looks like a GitHub username. If it starts with `http:` or `https:`, it will be fetched from the web. If you want to use a GitLab user's key for example, specify the full URL (e.g. `-u https://gitlab.com/USERNAME.keys`). Otherwise, it will be determined as a file path. If you specify a file that looks like GitHub username, specify it with a path (e.g. `-u ./octocat`). Required for encryption. For decryption, perform signature verification if specified.
-* `-k` Specify your private key. If not specified, it searches `~/.ssh/id_ecdsa`, `~/.ssh/id_ed25519`, `~/.ssh/id_rsa` in order and uses the first one found.
-* `-i` Input file. Plaintext file to be encrypted when encrypting. When decrypting, please specify the ciphertext file to be decrypted. If no options are specified, it reads from standard input.
-* `-o` output file. Outputs to standard output if no option is specified.
-* Specify `-d` for decrypt mode. Encrypted mode if not specified.
-* `-F` specifies the file version of the cipher file. Currently, versions `1` and `2` are valid. The default value is `1` for versions 0.0.9 and below, and `2` for versions 1.0.0 and above.  
-  **Note:** Format version `1` is deprecated and should not be used for new files.
+### Encryption and Signature Algorithms
 
-## Example of use
+#### Format version 2 (recommended; since v0.0.9)
 
-Encrypt your file `secret.txt` for GitHub user `octocat` and save it as `secret.zip`.
+| Algorithm        | Encryption/Decryption                       | Signing/Verification         |
+|------------------|---------------------------------------------|------------------------------|
+| AES              | AES-256-GCM                                 | N/A                          |
+| RSA              | RSA-OAEP (SHA-256)                          | RSA-PSS (SHA-256)            |
+| ECDSA/ECDH       | ECDH + HKDF-SHA-256 + AES-256-GCM           | ECDSA (SHA-256)              |
+| ED25519/X25519   | X25519 + HKDF-SHA-256 + AES-256-GCM         | ED25519 (SHA-512)            |
 
-```shell
-git-caesar -u octocat -i secret.txt -o secret.zip
-```
+#### Format version 1 (deprecated)
 
-In the same situation, the private key uses `~/.ssh/id_secret`.
+| Algorithm        | Encryption/Decryption                       | Signing/Verification         |
+|------------------|---------------------------------------------|------------------------------|
+| AES              | AES-256-CBC                                 | N/A                          |
+| RSA              | RSA-OAEP (SHA-256)                          | RSA-PKCS1-v1_5 (SHA-256)     |
+| ECDSA/ECDH       | ECDH + ⚠️SHA-256 (for key derivation) + AES-256-CBC   | ECDSA (SHA-256)   |
+| ED25519/X25519   | X25519 + ⚠️SHA-256 (for key derivation) + AES-256-CBC | ED25519 (⚠️with pre-hashed SHA-256 input) |
 
-```shell
-git-caesar -u octocat -i secret.txt -o secret.zip -k ~/.ssh/id_secret
-```
+## SECURITY
 
-Decrypt GitLab user `tanuki`'s file `secret.zip` and save it as `secret.txt`.
+In this tool, the ECDSA and ED25519 signing public keys are reused for key exchange (ECDH / X25519).
 
-```shell
-git-caesar -d -u https://gitlab.com/tanuki.keys -i secret.zip -o secret.txt
-```
+- Using the signing public key for key exchange does not directly leak the recipient’s signing private key during the key exchange itself, because the private key is not transmitted or revealed in the protocol.
+- The sender’s signing private key is also not leaked, as an ephemeral key for key exchange is used for each session on the sender’s side, and the sender's signing key is used only for signing.
 
-Same situation, no signature verification.
+However, this practice has the following potential security risks:
 
-```shell
-git-caesar -d -i secret.zip -o secret.txt
-```
+- If the signing private key is compromised, all past key exchanges using that key can be broken retroactively (forward secrecy is lost).
+- Increased use of the signing private key raises the risk of side-channel attacks.
 
-## Supported Public Key Algorithms
+## SEE ALSO
 
-List of supported public key prefixes:
+- dev.to [Passwordless encryption with public key for GitHub](https://dev.to/yoshi389111/passwordless-encryption-with-public-key-for-github-kb6) English
+- Qiita [GitHub 用の公開鍵でパスワードレスの暗号化/復号をしてみる](https://qiita.com/yoshi389111/items/238908e1933a8a4018c6) Japanese
 
-* `ssh-rsa` -- Key length is 1024 bits or more
-* `ecdsa-sha2-nistp256`
-* `ecdsa-sha2-nistp384`
-* `ecdsa-sha2-nistp521`
-* `ssh-ed25519`
+## LICENSE
 
-**Unsupported** public key prefix list:
-
-* `ssh-dss` -- DSA
-* `ssh-rsa` -- Key length is less than 1024 bits
-* `sk-ecdsa-sha2-nistp256@openssh.com`
-* `sk-ssh-ed25519@openssh.com`
-
-## Algorithms used
-
-### Format version 2 (since version 0.0.9)
-
-| Algorithm | Encryption/Decryption | Signing/Verification |
-|-----------|-----------------------|----------------------|
-| AES       | AES-256-GCM           | N/A                  |
-| RSA       | RSA-OAEP (SHA-256)    | RSA-PSS (SHA-256)    |
-| ECDSA/ECDH | ECDH + HKDF-SHA-256 + AES-256-GCM | ECDSA (SHA-256) |
-| ED25519/X25519 | X25519 + HKDF-SHA-256 + AES-256-GCM | ED25519 (SHA-512 internally) |
-
-### Format version 1 (**deprecated** since version 1.0.0)
-
-| Algorithm | Encryption/Decryption | Signing/Verification |
-|-----------|-----------------------|----------------------|
-| AES       | AES-256-CBC           | N/A                  |
-| RSA       | RSA-OAEP (SHA-256)    | RSA-PKCS1-v1_5 (SHA-256) |
-| ECDSA/ECDH | ECDH + ⚠️SHA-256 (for key derivation) + AES-256-CBC | ECDSA (SHA-256) |
-| ED25519/X25519 | X25519 + ⚠️SHA-256 (for key derivation) + AES-256-CBC | ED25519 (⚠️with pre-hashed SHA-256 input) |
-
-## Security Considerations
-
-In this command, the ecdsa / ed25519 public key for signing is reused for key exchange (ecdh / x25519).
-
-If you use this command to reuse a signing public key (such as ECDSA or Ed25519) as a key exchange public key (such as ECDH or X25519), there are some important security considerations. It’s not strictly forbidden in theory, but doing so carries these risks:
-
-* Using the signing public key for key exchange does not directly leak the recipient’s signing private key during the key exchange itself, because the private key is not transmitted or revealed in the protocol.
-
-* The sender’s own signing private key is also not leaked by this use, assuming ephemeral keys are used on the sender side for each session, and the sender’s signing key is only used for signatures.
-
-* **However, if the recipient’s signing private key is ever compromised**, all past key exchanges using that key can be broken retroactively, since the same secret scalar was used for all the Diffie-Hellman calculations. This means forward secrecy is lost.
-
-* Additionally, reusing the signing private key for key exchange calculations increases the number of operations using that key, which can expand the attack surface for side-channel attacks (e.g., timing or power analysis). More opportunities to observe operations can make extracting the private key easier in practice.
-
-* Finally, using the same key for both authentication (signatures) and key agreement (encryption) breaks clear separation of roles. It complicates key management, increases the consequences of a single key leak, and can introduce unforeseen protocol interactions.
-
-## Related Tech Blog Articles
-
-* dev.to [Passwordless encryption with public key for GitHub](https://dev.to/yoshi389111/passwordless-encryption-with-public-key-for-github-kb6) English
-* Qiita [GitHub 用の公開鍵でパスワードレスの暗号化/復号をしてみる](https://qiita.com/yoshi389111/items/238908e1933a8a4018c6) Japanese
-
-## Copyright and License
+MIT License
 
 &copy; 2023 SATO, Yoshiyuki
-
-This software is released under the MIT License.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This command encrypts and decrypts files using the public key registered on GitHub and your own private key.
 
+In addition to keys registered on github, you can also specify keys registered on gitlab or SSH keys in local files.
+
 ## Installation
 
 ### How to build with GO command
@@ -54,17 +56,44 @@ Application Options:
   -i, --input=<input_file>          the path of the file to read. default: stdin
   -o, --output=<output_file>        the path of the file to write. default: stdout
   -d, --decrypt                     decryption mode.
-  -F, --format-version=<version>    format version of the encrypted file. (default: 1)
+  -F, --format-version=<version>    format version of the encrypted file. (default: 2)
 ```
 
-* `-u` specifies the location of the peer's public key. Get from `https://github.com/USER_NAME.keys` if the one specified looks like a GitHub username. If it starts with `http:` or `https:`, it will be fetched from the web. Otherwise, it will be determined as a file path. If you specify a file that looks like GitHub username, specify it with a path (e.g. `-u ./octacat`). Required for encryption. For decryption, perform signature verification if specified.
+* `-u` specifies the location of the peer's public key. Get from `https://github.com/USER_NAME.keys` if the one specified looks like a GitHub username. If it starts with `http:` or `https:`, it will be fetched from the web. If you want to use a GitLab user's key for example, specify the full URL (e.g. `-u https://gitlab.com/USERNAME.keys`). Otherwise, it will be determined as a file path. If you specify a file that looks like GitHub username, specify it with a path (e.g. `-u ./octocat`). Required for encryption. For decryption, perform signature verification if specified.
 * `-k` Specify your private key. If not specified, it searches `~/.ssh/id_ecdsa`, `~/.ssh/id_ed25519`, `~/.ssh/id_rsa` in order and uses the first one found.
 * `-i` Input file. Plaintext file to be encrypted when encrypting. When decrypting, please specify the ciphertext file to be decrypted. If no options are specified, it reads from standard input.
 * `-o` output file. Outputs to standard output if no option is specified.
 * Specify `-d` for decrypt mode. Encrypted mode if not specified.
-* `-F` specifies the file version of the cipher file. Currently, versions 1 and 2 are valid.
+* `-F` specifies the file version of the cipher file. Currently, versions `1` and `2` are valid. The default value is `1` for versions 0.0.9 and below, and `2` for versions 1.0.0 and above.  
+  **Note:** Format version `1` is deprecated and should not be used for new files.
 
-## Supported algorithms
+## Example of use
+
+Encrypt your file `secret.txt` for GitHub user `octocat` and save it as `secret.zip`.
+
+```shell
+git-caesar -u octocat -i secret.txt -o secret.zip
+```
+
+In the same situation, the private key uses `~/.ssh/id_secret`.
+
+```shell
+git-caesar -u octocat -i secret.txt -o secret.zip -k ~/.ssh/id_secret
+```
+
+Decrypt GitLab user `tanuki`'s file `secret.zip` and save it as `secret.txt`.
+
+```shell
+git-caesar -d -u https://gitlab.com/tanuki.keys -i secret.zip -o secret.txt
+```
+
+Same situation, no signature verification.
+
+```shell
+git-caesar -d -i secret.zip -o secret.txt
+```
+
+## Supported Public Key Algorithms
 
 List of supported public key prefixes:
 
@@ -81,31 +110,41 @@ List of supported public key prefixes:
 * `sk-ecdsa-sha2-nistp256@openssh.com`
 * `sk-ssh-ed25519@openssh.com`
 
-## Example of use
+## Algorithms used
 
-Encrypt your file `secret.txt` for GitHub user `octacat` and save it as `secret.zip`.
+### Format version 2 (since version 0.0.9)
 
-```shell
-git-caesar -u octacat -i secret.txt -o secret.zip
-```
+| Algorithm | Encryption/Decryption | Signing/Verification |
+|-----------|-----------------------|----------------------|
+| AES       | AES-256-GCM           | N/A                  |
+| RSA       | RSA-OAEP (SHA-256)    | RSA-PSS (SHA-256)    |
+| ECDSA/ECDH | ECDH + HKDF-SHA-256 + AES-256-GCM | ECDSA (SHA-256) |
+| ED25519/X25519 | X25519 + HKDF-SHA-256 + AES-256-GCM | ED25519 (SHA-512 internally) |
 
-In the same situation, the private key uses `~/.ssh/id_secret`.
+### Format version 1 (**deprecated** since version 1.0.0)
 
-```shell
-git-caesar -u octacat -i secret.txt -o secret.zip -k ~/.ssh/id_secret
-```
+| Algorithm | Encryption/Decryption | Signing/Verification |
+|-----------|-----------------------|----------------------|
+| AES       | AES-256-CBC           | N/A                  |
+| RSA       | RSA-OAEP (SHA-256)    | RSA-PKCS1-v1_5 (SHA-256) |
+| ECDSA/ECDH | ECDH + ⚠️SHA-256 (for key derivation) + AES-256-CBC | ECDSA (SHA-256) |
+| ED25519/X25519 | X25519 + ⚠️SHA-256 (for key derivation) + AES-256-CBC | ED25519 (⚠️with pre-hashed SHA-256 input) |
 
-Decrypt GitLab user `tanuki`'s file `secret.zip` and save it as `secret.txt`.
+## Security Considerations
 
-```shell
-git-caesar -d -u https://gitlab.com/tanuki.keys -i secret.zip -o secret.txt
-```
+In this command, the ecdsa / ed25519 public key for signing is reused for key exchange (ecdh / x25519).
 
-Same situation, no signature verification.
+If you use this command to reuse a signing public key (such as ECDSA or Ed25519) as a key exchange public key (such as ECDH or X25519), there are some important security considerations. It’s not strictly forbidden in theory, but doing so carries these risks:
 
-```shell
-git-caesar -d -i secret.zip -o secret.txt
-```
+* Using the signing public key for key exchange does not directly leak the recipient’s signing private key during the key exchange itself, because the private key is not transmitted or revealed in the protocol.
+
+* The sender’s own signing private key is also not leaked by this use, assuming ephemeral keys are used on the sender side for each session, and the sender’s signing key is only used for signatures.
+
+* **However, if the recipient’s signing private key is ever compromised**, all past key exchanges using that key can be broken retroactively, since the same secret scalar was used for all the Diffie-Hellman calculations. This means forward secrecy is lost.
+
+* Additionally, reusing the signing private key for key exchange calculations increases the number of operations using that key, which can expand the attack surface for side-channel attacks (e.g., timing or power analysis). More opportunities to observe operations can make extracting the private key easier in practice.
+
+* Finally, using the same key for both authentication (signatures) and key agreement (encryption) breaks clear separation of roles. It complicates key management, increases the consequences of a single key leak, and can introduce unforeseen protocol interactions.
 
 ## Related Tech Blog Articles
 

--- a/getOpts.go
+++ b/getOpts.go
@@ -47,7 +47,7 @@ type Options struct {
 	InputPath     string      `short:"i" long:"input" value-name:"<input_file>" description:"the path of the file to read. default: stdin"`
 	OutputPath    string      `short:"o" long:"output" value-name:"<output_file>" description:"the path of the file to write. default: stdout"`
 	Decrypt       bool        `short:"d" long:"decrypt" description:"decryption mode."`
-	FormatVersion VersionType `short:"F" long:"format-version" value-name:"<version>" description:"format version of the encrypted file." default:"1"`
+	FormatVersion VersionType `short:"F" long:"format-version" value-name:"<version>" description:"format version of the encrypted file." default:"2"`
 }
 
 func getOpts() Options {

--- a/getOpts.go
+++ b/getOpts.go
@@ -47,7 +47,7 @@ type Options struct {
 	InputPath     string      `short:"i" long:"input" value-name:"<input_file>" description:"the path of the file to read. default: stdin"`
 	OutputPath    string      `short:"o" long:"output" value-name:"<output_file>" description:"the path of the file to write. default: stdout"`
 	Decrypt       bool        `short:"d" long:"decrypt" description:"decryption mode."`
-	FormatVersion VersionType `short:"F" long:"format-version" value-name:"<version>" description:"format version of the encrypted file." default:"2"`
+	FormatVersion VersionType `short:"F" long:"format-version" value-name:"<version>" description:"format version of the encrypted file." default:"3"`
 }
 
 func getOpts() Options {


### PR DESCRIPTION
This pull request introduces significant updates to the `git-caesar` project, including enhancements to documentation, changes to default encryption format, and expanded algorithm support. The most important changes include a complete rewrite of the `README.md` to improve usability and clarity, an update to the default encryption format version, and a detailed specification of supported and unsupported algorithms.

### Encryption Format Updates:
* [`getOpts.go`](diffhunk://#diff-77f2fc53f4187fab5449cb792d06731b8e7c22d04584709822cb7e6519036691L49-R49): Changed the default encryption format version from `1` (deprecated) to `2` (recommended) in the `FormatVersion` field of the `Options` struct. This ensures new users benefit from improved security features by default.

### Documentation Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R86): Rewritten to include detailed sections such as `NAME`, `SYNOPSIS`, `DESCRIPTION`, `OPTIONS`, `EXAMPLES`, `SUPPORTED ALGORITHMS`, and `SECURITY`. This improves clarity and usability for users by providing comprehensive instructions and additional context about the tool's functionality. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R86) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-L119)

### Algorithm Specification:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-L119): Added detailed tables specifying supported and unsupported public key algorithms, as well as encryption and signature algorithms for both format versions. This provides users with clear guidelines on compatibility and security considerations.