### PR TITLE
:sparkles: feat: Add support for version 3 in encryption and decryption processes, update tests and scripts

### DIFF
--- a/caesar/aes/aes.go
+++ b/caesar/aes/aes.go
@@ -16,7 +16,7 @@ func Encrypt(version string, key, plaintext []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
 		return encryptV1(key, plaintext)
-	case common.Version2:
+	case common.Version2, common.Version3:
 		return encryptV2(key, plaintext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -80,7 +80,7 @@ func Decrypt(version string, key, ciphertext []byte) ([]byte, error) {
 	switch version {
 	case common.Version1:
 		return decryptV1(key, ciphertext)
-	case common.Version2:
+	case common.Version2, common.Version3:
 		return decryptV2(key, ciphertext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)

--- a/caesar/common/versions.go
+++ b/caesar/common/versions.go
@@ -5,4 +5,6 @@ const (
 	Version1 string = "1"
 	// Version2 is the second version of caesar.json format.
 	Version2 string = "2"
+	// Version3 is the 3rd version of caesar.json format.
+	Version3 string = "3"
 )

--- a/caesar/ecdsa/ecdsa_test.go
+++ b/caesar/ecdsa/ecdsa_test.go
@@ -34,10 +34,11 @@ func Test_Encrypt_Decrypt_ecdsa(t *testing.T) {
 		formatVersion string
 	}{
 		"ecdsa256_formatVer1": {"P256", "1"},
-
 		"ecdsa256_formatVer2": {"P256", "2"},
-		"ecdsa384_formatVer2": {"P384", "2"},
-		"ecdsa521_formatVer2": {"P521", "2"},
+
+		"ecdsa256_formatVer3": {"P256", "3"},
+		"ecdsa384_formatVer3": {"P384", "3"},
+		"ecdsa521_formatVer3": {"P521", "3"},
 	}
 
 	message := []byte("hello world --------------- 0256") // 32byte
@@ -96,10 +97,11 @@ func Test_Sign_Verify_ecdsa(t *testing.T) {
 		formatVersion string
 	}{
 		"ecdsa256_formatVer1": {"P256", "1"},
-
 		"ecdsa256_formatVer2": {"P256", "2"},
-		"ecdsa384_formatVer2": {"P384", "2"},
-		"ecdsa521_formatVer2": {"P521", "2"},
+
+		"ecdsa256_formatVer3": {"P256", "3"},
+		"ecdsa384_formatVer3": {"P384", "3"},
+		"ecdsa521_formatVer3": {"P521", "3"},
 	}
 
 	message := []byte("hello world --------------- 0521")
@@ -134,10 +136,11 @@ func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
 		formatVersion string
 	}{
 		"ecdsa256_formatVer1": {"P256", "1"},
-
 		"ecdsa256_formatVer2": {"P256", "2"},
-		"ecdsa384_formatVer2": {"P384", "2"},
-		"ecdsa521_formatVer2": {"P521", "2"},
+
+		"ecdsa256_formatVer3": {"P256", "3"},
+		"ecdsa384_formatVer3": {"P384", "3"},
+		"ecdsa521_formatVer3": {"P521", "3"},
 	}
 
 	message := []byte("hello world --------------- 1024") // 32byte
@@ -183,10 +186,11 @@ func Test_PrivateKeySign_PublicKeyVerify(t *testing.T) {
 		formatVersion string
 	}{
 		"ecdsa256_formatVer1": {"P256", "1"},
-
 		"ecdsa256_formatVer2": {"P256", "2"},
-		"ecdsa384_formatVer2": {"P384", "2"},
-		"ecdsa521_formatVer2": {"P521", "2"},
+
+		"ecdsa256_formatVer3": {"P256", "3"},
+		"ecdsa384_formatVer3": {"P384", "3"},
+		"ecdsa521_formatVer3": {"P521", "3"},
 	}
 
 	message := []byte("hello world --------------- 1024") // 32byte

--- a/caesar/ed25519/ed25519.go
+++ b/caesar/ed25519/ed25519.go
@@ -20,7 +20,7 @@ func Encrypt(version string, peerPubKey *ed25519.PublicKey, message []byte) ([]b
 	switch version {
 	case common.Version1:
 		return encryptV1(version, peerPubKey, message)
-	case common.Version2:
+	case common.Version2, common.Version3:
 		return encryptV2(version, peerPubKey, message)
 	default:
 		return nil, nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -93,7 +93,7 @@ func Decrypt(version string, prvKey *ed25519.PrivateKey, peerPubKey *ed25519.Pub
 	switch version {
 	case common.Version1:
 		return decryptV1(version, prvKey, peerPubKey, ciphertext)
-	case common.Version2:
+	case common.Version2, common.Version3:
 		return decryptV2(version, prvKey, peerPubKey, ciphertext)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -170,7 +170,7 @@ func Sign(version string, prvKey *ed25519.PrivateKey, message []byte) ([]byte, e
 	switch version {
 	case common.Version1:
 		return signV1(prvKey, message)
-	case common.Version2:
+	case common.Version2, common.Version3:
 		return signV2(prvKey, message)
 	default:
 		return nil, fmt.Errorf("unknown `caesar.json` version `%s`", version)
@@ -196,7 +196,7 @@ func Verify(version string, pubKey *ed25519.PublicKey, message, sig []byte) bool
 	switch version {
 	case common.Version1:
 		return verifyV1(pubKey, message, sig)
-	case common.Version2:
+	case common.Version2, common.Version3:
 		return verifyV2(pubKey, message, sig)
 	default:
 		return false // unknown version

--- a/caesar/ed25519/ed25519_test.go
+++ b/caesar/ed25519/ed25519_test.go
@@ -15,6 +15,7 @@ func Test_Encrypt_Decrypt_ed25519(t *testing.T) {
 	}{
 		"ed25519_formatVer1": {"1"},
 		"ed25519_formatVer2": {"2"},
+		"ed25519_formatVer3": {"3"},
 	}
 
 	message := []byte("hello world --------------- 0256") // 32byte
@@ -67,6 +68,7 @@ func Test_Sign_Verify(t *testing.T) {
 	}{
 		"ed25519_formatVer1": {"1"},
 		"ed25519_formatVer2": {"2"},
+		"ed25519_formatVer3": {"3"},
 	}
 
 	message := []byte("hello world --------------- 0521")
@@ -95,6 +97,7 @@ func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
 	}{
 		"ed25519_formatVer1": {"1"},
 		"ed25519_formatVer2": {"2"},
+		"ed25519_formatVer3": {"3"},
 	}
 
 	message := []byte("hello world --------------- 1024") // 32byte
@@ -136,6 +139,7 @@ func Test_PrivateKeySign_PublicKeyVerify(t *testing.T) {
 	}{
 		"ed25519_formatVer1": {"1"},
 		"ed25519_formatVer2": {"2"},
+		"ed25519_formatVer3": {"3"},
 	}
 
 	message := []byte("hello world --------------- 1024") // 32byte

--- a/caesar/rsa/rsa_test.go
+++ b/caesar/rsa/rsa_test.go
@@ -45,9 +45,9 @@ func Test_EncryptDecryptRsa(t *testing.T) {
 		"rsa2048_formatVer1": {2048, "1"},
 		"rsa2048_formatVer2": {2048, "2"},
 
-		"rsa1024_formatVer3": {1024, "2"},
-		"rsa2048_formatVer3": {2048, "2"},
-		"rsa4096_formatVer3": {4096, "2"},
+		"rsa1024_formatVer3": {1024, "3"},
+		"rsa2048_formatVer3": {2048, "3"},
+		"rsa4096_formatVer3": {4096, "3"},
 	}
 
 	message := []byte("hello world ------------ 32 byte")

--- a/caesar/rsa/rsa_test.go
+++ b/caesar/rsa/rsa_test.go
@@ -5,10 +5,37 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/hex"
+	"fmt"
+	"sync"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
 )
+
+var (
+	rsaKeys  = make(map[int]*rsa.PrivateKey)
+	keysOnce sync.Once
+)
+
+func generateTestKeys() {
+	bitLengths := []int{1024, 2048, 4096}
+	for _, bits := range bitLengths {
+		key, err := rsa.GenerateKey(rand.Reader, bits)
+		if err != nil {
+			panic(err)
+		}
+		rsaKeys[bits] = key
+	}
+}
+
+func getTestKey(bits int) (*rsa.PrivateKey, error) {
+	keysOnce.Do(generateTestKeys)
+	key, exists := rsaKeys[bits]
+	if !exists {
+		return nil, fmt.Errorf("test key not found for bit length: %d", bits)
+	}
+	return key, nil
+}
 
 func Test_EncryptDecryptRsa(t *testing.T) {
 	cases := map[string]struct {
@@ -16,16 +43,17 @@ func Test_EncryptDecryptRsa(t *testing.T) {
 		formatVersion string
 	}{
 		"rsa2048_formatVer1": {2048, "1"},
-
-		"rsa1024_formatVer2": {1024, "2"},
 		"rsa2048_formatVer2": {2048, "2"},
-		"rsa4096_formatVer2": {4096, "2"},
+
+		"rsa1024_formatVer3": {1024, "2"},
+		"rsa2048_formatVer3": {2048, "2"},
+		"rsa4096_formatVer3": {4096, "2"},
 	}
 
 	message := []byte("hello world ------------ 32 byte")
 	for name, tc := range cases {
 		t.Run("Encrypt_Decrypt_"+name, func(t *testing.T) {
-			prvKey, err := rsa.GenerateKey(rand.Reader, tc.keyLength)
+			prvKey, err := getTestKey(tc.keyLength)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -72,16 +100,17 @@ func Test_SignVerifyRsa(t *testing.T) {
 		formatVersion string
 	}{
 		"rsa2048_formatVer1": {2048, "1"},
-
-		"rsa1024_formatVer2": {1024, "2"},
 		"rsa2048_formatVer2": {2048, "2"},
-		"rsa4096_formatVer2": {4096, "2"},
+
+		"rsa1024_formatVer3": {1024, "2"},
+		"rsa2048_formatVer3": {2048, "2"},
+		"rsa4096_formatVer3": {4096, "2"},
 	}
 
 	message := []byte("hello world ------------ 32 byte")
 	for name, tc := range cases {
 		t.Run("Sign_Verify_"+name, func(t *testing.T) {
-			prvKey, err := rsa.GenerateKey(rand.Reader, tc.keyLength)
+			prvKey, err := getTestKey(tc.keyLength)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -106,12 +135,13 @@ func Test_NewEnvelope_ExtractShareKey(t *testing.T) {
 	}{
 		"rsa2048_formatVer1": {2048, "1"},
 		"rsa2048_formatVer2": {2048, "2"},
+		"rsa2048_formatVer3": {2048, "3"},
 	}
 
 	message := []byte("hello world ------------ 32 byte")
 	for name, tc := range cases {
 		t.Run("NewEnvelope_ExtractShareKey_"+name, func(t *testing.T) {
-			prvKey, err := rsa.GenerateKey(rand.Reader, tc.keyLength)
+			prvKey, err := getTestKey(tc.keyLength)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -149,12 +179,15 @@ func Test_PrivateKeySign_PublicKeyVerify(t *testing.T) {
 	}{
 		"rsa2048_formatVer1": {2048, "1"},
 		"rsa2048_formatVer2": {2048, "2"},
+
+		"rsa2048_formatVer3": {2048, "3"},
+		"rsa4096_formatVer3": {4096, "3"},
 	}
 
 	message := []byte("hello world --------------- 1024") // 32byte
 	for name, tc := range cases {
 		t.Run("PrivateKey_PublicKey_"+name, func(t *testing.T) {
-			prvKey, err := rsa.GenerateKey(rand.Reader, tc.keyLength)
+			prvKey, err := getTestKey(tc.keyLength)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -181,7 +214,7 @@ func Test_PrivateKeySign_PublicKeyVerify(t *testing.T) {
 }
 
 func Test_EncryptDecryptRsa_InvalidVersion(t *testing.T) {
-	prvKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	prvKey, err := getTestKey(2048)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +233,7 @@ func Test_EncryptDecryptRsa_InvalidVersion(t *testing.T) {
 }
 
 func Test_SignVerifyRsa_InvalidVersion(t *testing.T) {
-	prvKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	prvKey, err := getTestKey(2048)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +256,7 @@ func Test_SignVerifyRsa_InvalidVersion(t *testing.T) {
 }
 
 func Test_EncryptDecryptRsa_WrongKey(t *testing.T) {
-	prvKey1, err := rsa.GenerateKey(rand.Reader, 2048)
+	prvKey1, err := getTestKey(2048)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,11 +285,12 @@ func Test_SignVerifyRsa_WrongKey(t *testing.T) {
 	}{
 		"rsa2048_formatVer1": {2048, "1"},
 		"rsa2048_formatVer2": {2048, "2"},
+		"rsa2048_formatVer3": {2048, "3"},
 	}
 	for name, tc := range cases {
 		t.Run("Sign_Verify_wrong_key_"+name, func(t *testing.T) {
 
-			prvKey1, err := rsa.GenerateKey(rand.Reader, tc.keyLength)
+			prvKey1, err := getTestKey(tc.keyLength)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -286,12 +320,13 @@ func Test_SignVerifyRsa_ModifiedMessage(t *testing.T) {
 	}{
 		"rsa2048_formatVer1": {2048, "1"},
 		"rsa2048_formatVer2": {2048, "2"},
+		"rsa2048_formatVer3": {2048, "3"},
 	}
 
 	for name, tc := range cases {
 		t.Run("Sign_Verify_modified_message/"+name, func(t *testing.T) {
 
-			prvKey, err := rsa.GenerateKey(rand.Reader, tc.keyLength)
+			prvKey, err := getTestKey(tc.keyLength)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/caesar/rsa/rsa_test.go
+++ b/caesar/rsa/rsa_test.go
@@ -102,9 +102,9 @@ func Test_SignVerifyRsa(t *testing.T) {
 		"rsa2048_formatVer1": {2048, "1"},
 		"rsa2048_formatVer2": {2048, "2"},
 
-		"rsa1024_formatVer3": {1024, "2"},
-		"rsa2048_formatVer3": {2048, "2"},
-		"rsa4096_formatVer3": {4096, "2"},
+		"rsa1024_formatVer3": {1024, "3"},
+		"rsa2048_formatVer3": {2048, "3"},
+		"rsa4096_formatVer3": {4096, "3"},
 	}
 
 	message := []byte("hello world ------------ 32 byte")

--- a/getOpts.go
+++ b/getOpts.go
@@ -17,6 +17,7 @@ type VersionType string
 var caesarJsonVersions = []VersionType{
 	VersionType(common.Version1),
 	VersionType(common.Version2),
+	VersionType(common.Version3),
 }
 
 func IsValidCaesarJsonVersion(v string) bool {

--- a/roundtrip.sh
+++ b/roundtrip.sh
@@ -38,7 +38,7 @@ EOF
 
 HAS_ERROR=0
 
-for VERSION in 1 2; do
+for VERSION in 1 2 3; do
 
     for ALICE_KEY_TYPE in rsa ecdsa ed25519; do
 


### PR DESCRIPTION
This pull request introduces support for a new version (`Version3`) of the `caesar.json` format across multiple cryptographic implementations (`AES`, `ECDSA`, `Ed25519`, and `RSA`). It also enhances the RSA test suite by introducing reusable test keys for various bit lengths. Below is a summary of the most important changes grouped by theme.

### Support for `Version3`:

* Added `Version3` constant in `caesar/common/versions.go` to define the new format version.
* Updated encryption, decryption, signing, and verification functions across `AES`, `ECDSA`, `Ed25519`, and `RSA` implementations to handle `Version3`. [[1]](diffhunk://#diff-027267dc852bbd81157d879ec79f16c184d53b67c0e4dde55d1a6a74dfa33358L19-R19) [[2]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941L24-R26) [[3]](diffhunk://#diff-f1885b99c35c6afc570bfd4599063d108239e79c2cfe520a8f8f0f4f13277464L23-R23) [[4]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67L22-R22) and related references)

### ECDSA Enhancements:

* Introduced `signV3` and `verifyV3` methods in `caesar/ecdsa/ecdsa.go` to handle `Version3` signatures using curve-specific hashing. [[1]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941R201-R219) [[2]](diffhunk://#diff-8c29025fd9ea94b6ab8b91e2fba6236ac0523d141783084a6b060acf5f1da941R229-R252)
* Added `curveHash` utility to compute hashes based on elliptic curve type.

### RSA Enhancements:

* Added `signV3` and `verifyV3` methods in `caesar/rsa/rsa.go` to support `Version3` signatures with dynamic hash selection based on key bit length. [[1]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R81-R98) [[2]](diffhunk://#diff-a03ad68b10d0268ab0edb65a09c6c0c17c08bc90c12cf7f55912b8f409ac4c67R115-R143)
* Introduced `selectHash` and `calcHash` utilities for dynamic hash selection and computation.

### Test Suite Improvements:

* Extended test cases for `Version3` across all cryptographic implementations (`AES`, `ECDSA`, `Ed25519`, and `RSA`). [[1]](diffhunk://#diff-3888fb1b5129b446fdc33ff3030fd8ff8565c39349f721f58ad17de5fde3388dL37-R41) [[2]](diffhunk://#diff-6caa8f42ce959bf93a99ced151207a1853619e5d15e3f85a7127806b7781f3dbR18) [[3]](diffhunk://#diff-9be1347992019ca125ac5b96119399e748c9daea87ff5f7525edd8c25df79e07L75-R113) and related references)
* Refactored RSA tests to use reusable test keys generated once per test run, ensuring consistency and efficiency.

### Miscellaneous:

* Added new imports for cryptographic utilities (`elliptic`, `sha512`) in `ECDSA` implementation to support curve-specific hashing.
* Refactored RSA test cases to replace inline key generation with reusable keys. [[1]](diffhunk://#diff-9be1347992019ca125ac5b96119399e748c9daea87ff5f7525edd8c25df79e07R8-R56) [[2]](diffhunk://#diff-9be1347992019ca125ac5b96119399e748c9daea87ff5f7525edd8c25df79e07L75-R113)…on processes, update tests and scripts