### PR TITLE
:wrench: env:  create Third Party Licenses for dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL = /bin/sh
 VERSION = $(shell git describe --tags --abbrev=0)
 GOFLAGS = -ldflags "-s -w -X main.version=$(shell git describe --tags --dirty)"
+MODULE_NAME = $(shell go list -m)
 
 .DEFAULT_GOAL = help
 help: ## Show help message
@@ -23,3 +24,15 @@ test: ## Unit test
 roundtrip: build ## Roundtrip test
 	./roundtrip.sh
 .PHONY: roundtrip
+
+licenses: ## Create Third Party Licenses
+	@# requires go-licenses tool
+	@# ```shell
+	@# go install github.com/google/go-licenses@latest
+	@# ```
+	@rm -rf licenses
+	@go-licenses save ./... --save_path=licenses --force
+	@rm -rf licenses/$(MODULE_NAME)
+	@find licenses -type d -empty -delete
+	@go-licenses csv ./... | grep -v "^$(MODULE_NAME)," > licenses/THIRD_PARTY_LICENSES.csv
+.PHONY: licenses

--- a/licenses/THIRD_PARTY_LICENSES.csv
+++ b/licenses/THIRD_PARTY_LICENSES.csv
@@ -1,0 +1,4 @@
+github.com/jessevdk/go-flags,https://github.com/jessevdk/go-flags/blob/v1.6.1/LICENSE,BSD-3-Clause
+golang.org/x/crypto,https://cs.opensource.google/go/x/crypto/+/v0.36.0:LICENSE,BSD-3-Clause
+golang.org/x/sys/unix,https://cs.opensource.google/go/x/sys/+/v0.31.0:LICENSE,BSD-3-Clause
+golang.org/x/term,https://cs.opensource.google/go/x/term/+/v0.30.0:LICENSE,BSD-3-Clause

--- a/licenses/github.com/jessevdk/go-flags/LICENSE
+++ b/licenses/github.com/jessevdk/go-flags/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2012 Jesse van den Kieboom. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following disclaimer
+     in the documentation and/or other materials provided with the
+     distribution.
+   * Neither the name of Google Inc. nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/golang.org/x/crypto/LICENSE
+++ b/licenses/golang.org/x/crypto/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/golang.org/x/sys/unix/LICENSE
+++ b/licenses/golang.org/x/sys/unix/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/golang.org/x/term/LICENSE
+++ b/licenses/golang.org/x/term/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This pull request introduces a new `licenses` target in the `Makefile` to manage third-party licenses and adds corresponding license files and a CSV summary for dependencies. Below are the most important changes:

### Third-party license management:

* Added a new `licenses/THIRD_PARTY_LICENSES.csv` file summarizing the licenses of dependencies, including links to the license files and their types. (`licenses/THIRD_PARTY_LICENSES.csv`, [licenses/THIRD_PARTY_LICENSES.csvR1-R4](diffhunk://#diff-90c0adb2712144a7a2f5ed2ed8426cfdd628b1eaa01e2abdebc96465977abab8R1-R4))
* Added individual license files for dependencies such as `github.com/jessevdk/go-flags`, `golang.org/x/crypto`, `golang.org/x/sys/unix`, and `golang.org/x/term`, ensuring compliance with license requirements. (`licenses/github.com/jessevdk/go-flags/LICENSE`, [[1]](diffhunk://#diff-18cfc8ca9932b8fb3f7fdb23a19093f20d12e6e21bc2744ce872105cc722db9bR1-R26); `licenses/golang.org/x/crypto/LICENSE`, [[2]](diffhunk://#diff-43d59bcf916cee080737ec88b724205d9a418a693ab608d9a546e74a0cb9ca24R1-R27); `licenses/golang.org/x/sys/unix/LICENSE`, [[3]](diffhunk://#diff-43d59bcf916cee080737ec88b724205d9a418a693ab608d9a546e74a0cb9ca24R1-R27); `licenses/golang.org/x/term/LICENSE`, [[4]](diffhunk://#diff-43d59bcf916cee080737ec88b724205d9a418a693ab608d9a546e74a0cb9ca24R1-R27)

### Enhancements to `Makefile`:

* Added a `MODULE_NAME` variable to dynamically fetch the module name using `go list -m`. This is used in the new `licenses` target. (`Makefile`, [MakefileR4](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R4))
* Introduced a `licenses` target to generate a directory of third-party licenses and a CSV summary (`licenses/THIRD_PARTY_LICENSES.csv`). This includes instructions for installing the `go-licenses` tool. (`Makefile`, [MakefileR27-R38](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R27-R38))

